### PR TITLE
Add entry points for PYTHON and CXX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PYTHON ?= python2
+CXX ?= clang
 
 all:
 	$(MAKE) -C icebox

--- a/icebox/Makefile
+++ b/icebox/Makefile
@@ -3,11 +3,11 @@ DESTDIR = /usr/local
 all: chipdb-1k.txt chipdb-8k.txt
 
 chipdb-1k.txt: icebox.py iceboxdb.py icebox_chipdb.py
-	python2 icebox_chipdb.py > chipdb-1k.new
+	$(PYTHON) icebox_chipdb.py > chipdb-1k.new
 	mv chipdb-1k.new chipdb-1k.txt
 
 chipdb-8k.txt: icebox.py iceboxdb.py icebox_chipdb.py
-	python2 icebox_chipdb.py -8 > chipdb-8k.new
+	$(PYTHON) icebox_chipdb.py -8 > chipdb-8k.new
 	mv chipdb-8k.new chipdb-8k.txt
 
 clean:

--- a/icebox/Makefile
+++ b/icebox/Makefile
@@ -1,3 +1,4 @@
+PYTHON ?= python2
 DESTDIR = /usr/local
 
 all: chipdb-1k.txt chipdb-8k.txt

--- a/icefuzz/Makefile
+++ b/icefuzz/Makefile
@@ -27,8 +27,8 @@ else
 	cp cached_ramb_8k.txt bitdata_ramb_8k.txt
 	cp cached_ramt_8k.txt bitdata_ramt_8k.txt
 endif
-	python2 database.py
-	python2 export.py
+	$(PYTHON) database.py
+	$(PYTHON) export.py
 	diff -U0 cached_io.txt bitdata_io.txt || cp -v bitdata_io.txt cached_io.txt
 	diff -U0 cached_logic.txt bitdata_logic.txt || cp -v bitdata_logic.txt cached_logic.txt
 	diff -U0 cached_ramb.txt bitdata_ramb.txt || cp -v bitdata_ramb.txt cached_ramb.txt
@@ -63,13 +63,13 @@ datafiles: $(addprefix data_,$(addsuffix .txt,$(TESTS)))
 define data_template
 data_$(1).txt: make_$(1).py ../icepack/icepack
 ifeq ($(EIGTHK),_8k)
-	ICE8KPINS=1 python2 make_$(1).py
+	ICE8KPINS=1 $(PYTHON) make_$(1).py
 	ICEDEV=hx8k-ct256 $$(MAKE) -C work_$(1)
-	python2 extract.py -8 work_$(1)/*.glb > $$@
+	$$(PYTHON) extract.py -8 work_$(1)/*.glb > $$@
 else
-	python2 make_$(1).py
+	$$(PYTHON) make_$(1).py
 	$$(MAKE) -C work_$(1)
-	python2 extract.py work_$(1)/*.glb > $$@
+	$$(PYTHON) extract.py work_$(1)/*.glb > $$@
 endif
 endef
 

--- a/icemulti/Makefile
+++ b/icemulti/Makefile
@@ -1,4 +1,5 @@
 # CXX = clang
+CXX ?= clang
 LDLIBS = -lm -lstdc++
 CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11
 CC = $(CXX)

--- a/icepack/Makefile
+++ b/icepack/Makefile
@@ -1,6 +1,7 @@
 # CXX = clang
+CXX ?= clang
 LDLIBS = -lm -lstdc++
-CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11
+CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include
 CC = $(CXX)
 DESTDIR = /usr/local
 

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,6 +1,6 @@
 # CC = clang
-LDLIBS = -lftdi -lm
-CFLAGS = -MD -O0 -ggdb -Wall -std=c99
+LDLIBS = -L/usr/local/lib -lftdi -lm
+CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 DESTDIR = /usr/local
 
 all: iceprog


### PR DESCRIPTION
Hola!

This PR gives users the ability to build icestorm on machines that have differently named python interpreters (and also c++ compilers).

This for example, allows for building on OpenBSD:
```
env PYTHON=python2.7 CXX=eg++ gmake
```
I also added includes and libs from /usr/local as this is where libftdi and friends are located on OpenBSD.

I was also wondering about the licensing of this project. It doesn't seem to contain any license information. Is that something you will add later down the line?
***edit***: Found a [reference](https://hackaday.io/project/6636-iced-an-arduino-style-board-with-ice-fpga) to it being MIT, but clarification would still be awesome :D

