### PR TITLE
Icebox Makefile install section fixed

### DIFF
--- a/icebox/Makefile
+++ b/icebox/Makefile
@@ -16,6 +16,7 @@ clean:
 
 install: all
 	mkdir -p $(DESTDIR)/share/icebox
+	mkdir -p $(DESTDIR)/bin
 	cp chipdb-1k.txt     $(DESTDIR)/share/icebox/
 	cp chipdb-8k.txt     $(DESTDIR)/share/icebox/
 	cp icebox.py         $(DESTDIR)/bin/icebox.py


### PR DESCRIPTION
Hi! I am testing Icestorm debian packaging for launchpad and I found a bug in the "icestorm/Makefile".

I have detected it while running:
$ fakeroot debian/rules binary-arch

Regards!