### PR TITLE
fix CRAM command doc

### DIFF
--- a/docs/format.html
+++ b/docs/format.html
@@ -47,7 +47,7 @@ The following commands are known:
 
 <table class="ctab">
 <tr><th>Opcode</th><th>Description</th></tr>
-<tr><td>0</td><td>payload=0: CRAM Data<br/>
+<tr><td>0</td><td>payload=1: CRAM Data<br/>
                   payload=3: BRAM Data<br/>
 		  payload=5: Reset CRC<br/>
 		  payload=6: Wakeup<br/>


### PR DESCRIPTION
The documentation of the CRAM data command in the bitstream documentation seems to be wrong. In actual bitstreams generated by icepack, the payload is 0x01 and not 0x00 as documented. See also icepack.cc:264.