### PR TITLE
Add installation instruction for Archlinux to the website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,6 +77,10 @@ sudo apt-get install build-essential clang bison flex libreadline-dev \
 </pre>
 
 <p>
+If you are an Archlinux user, just install <a href="https://aur.archlinux.org/packages/icestorm-git/">icestorm-git</a>, <a href="https://aur.archlinux.org/packages/arachne-pnr-git/">arachne-pnr-git</a> and <a href="https://aur.archlinux.org/packages/yosys-git/">yosys-git</a> from the Arch User Repository (no need for the following installation steps).
+</p>
+
+<p>
 Installing the <a href="https://github.com/cliffordwolf/icestorm">IceStorm Tools</a> (icepack, icebox, iceprog):
 </p>
 


### PR DESCRIPTION
This adds installation instructions for Archlinux to the website.

Initially I was planning on releasing Archlinux packages myself, but someone was faster. It's really great that making Archlinux packages is so easy!