### PR TITLE
icetime: fixed chipdb path issue for Arch Linux

### DIFF
--- a/icetime/Makefile
+++ b/icetime/Makefile
@@ -1,6 +1,6 @@
 include ../config.mk
 LDLIBS = -lm -lstdc++
-CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include
+CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include -DPREFIX=$(PREFIX)
 
 all: icetime
 

--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -31,6 +31,9 @@
 // add this number of ns as estimate for clock distribution mismatch
 #define GLOBAL_CLK_DIST_JITTER 0.1
 
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
 FILE *fin = nullptr, *fout = nullptr, *frpt = nullptr;
 bool verbose = false;
 bool max_span_hack = false;
@@ -265,7 +268,7 @@ void read_config()
 void read_chipdb()
 {
 	char buffer[1024];
-	snprintf(buffer, 1024, "/usr/local/share/icebox/chipdb-%s.txt", config_device.c_str());
+	snprintf(buffer, 1024, TOSTRING(PREFIX) "/share/icebox/chipdb-%s.txt", config_device.c_str());
 
 	FILE *fdb = fopen(buffer, "r");
 	if (fdb == nullptr) {


### PR DESCRIPTION
Icetime was hardcoding the path to chipdb as /usr/local/share causing
icetime to not find the chip db on Arch Linux where the prefix is just
/usr/share.

With this commit the PREFIX is passed as a preprocessor define and used
in icetime.cc to create the correct path. I don't know what the
canonical way of dealing with this is, but this was the least intrusive
way I could think of to get this fixed.

This resolves https://github.com/cliffordwolf/icestorm/issues/24