### PR TITLE
Two small improvements.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
 CXX = clang
 CC = $(CXX)
-DESTDIR =
-PREFIX = /usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local

--- a/examples/iceblink/Makefile
+++ b/examples/iceblink/Makefile
@@ -1,0 +1,26 @@
+PROJ = example
+PIN_DEF = iceblink.pcf
+DEVICE = 1k
+
+all: $(PROJ).bin
+
+%.blif: %.v
+	yosys -p 'synth_ice40 -top top -blif $@' $<
+
+%.asc: $(PIN_DEF) %.blif
+	arachne-pnr -d $(DEVICE) -o $@ -p $^ -P vq100
+
+%.bin: %.asc
+	icepack $< $@
+
+prog: $(PROJ).bin
+	iCEburn.py  -e -v -w  $<
+
+sudo-prog: $(PROJ).bin
+	@echo 'Executing prog as root!!!'
+	iCEburn.py  -e -v -w  $<
+
+clean:
+	rm -f $(PROJ).blif $(PROJ).asc $(PROJ).bin
+
+.PHONY: all prog clean

--- a/examples/iceblink/README
+++ b/examples/iceblink/README
@@ -1,0 +1,10 @@
+Note, there are at least two similar looking versions of the iCEblink40 evaluation board:
+-iCEblink40-HX1K
+-iCEblink40-LP1K
+
+This example assumes the iCEblink40-HX1K board.
+
+The iCEblink40 boards have an on-board programmer with USB interface from Digilent.
+You need iCEburn to program the FPGA via this interface (or the original vendor 
+tools).
+https://github.com/davidcarne/iceBurn

--- a/examples/iceblink/example.v
+++ b/examples/iceblink/example.v
@@ -1,0 +1,24 @@
+/* Binary counter displayed on LEDs (the 4 green ones on the right).
+ * Changes value about once a second.
+ */
+module top (
+	input  clk,
+	output LED2,
+	output LED3,
+	output LED4,
+	output LED5
+);
+
+	localparam BITS = 4;
+	localparam LOG2DELAY = 22;
+
+	reg [BITS+LOG2DELAY-1:0] counter = 0;
+	reg [BITS-1:0] outcnt;
+
+	always@(posedge clk) begin
+		counter <= counter + 1;
+		outcnt <= counter >> LOG2DELAY;
+	end
+
+	assign {LED2, LED3, LED4, LED5} = outcnt;
+endmodule

--- a/examples/iceblink/iceblink.pcf
+++ b/examples/iceblink/iceblink.pcf
@@ -1,0 +1,5 @@
+set_io LED2 59
+set_io LED3 56
+set_io LED4 53
+set_io LED5 51
+set_io clk 13


### PR DESCRIPTION
-Take the install prefix from environment. I hope icestorm, arachne-pnr and yosys could all be installed to $PREFIX directory without Makefile/config.mk modifications.
-Adapt the example program to the iceblink board.