### PR TITLE
[Icetime] PREFIX expansion for locating the chipdb files in the user …

### DIFF
--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -265,7 +265,17 @@ void read_config()
 void read_chipdb()
 {
 	char buffer[1024];
-	snprintf(buffer, 1024, PREFIX "/share/icebox/chipdb-%s.txt", config_device.c_str());
+	char path[1024];
+
+	//-- If the PREFIX initial character is ~ expand it the
+	//-- home directory
+	if (strlen(PREFIX)>0 && PREFIX[0]=='~')
+	  snprintf(path, 1024, "%s%s", getenv("HOME"), &PREFIX[1]);
+	else
+	  snprintf(path, 1024, "%s", PREFIX);
+
+    //-- Chipdb file with full path
+	snprintf(buffer, 1024, "%s/share/icebox/chipdb-%s.txt", path, config_device.c_str());
 
 	FILE *fdb = fopen(buffer, "r");
 	if (fdb == nullptr) {


### PR DESCRIPTION
…home directory

Prefixes like "~/whatever" can now be used for the PREFIX variable.
We need this patch in order to make icetime work correctly when it is installed in the path ~/.platformio/packages/toolchain-icestorm/
We need it for supporting the icestorm tools in platformio

