### PR TITLE
Add STATIC flag to make: icepack, iceprog, icetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 icestorm-win32.zip
 icestorm-win32/
+*.new

--- a/icepack/Makefile
+++ b/icepack/Makefile
@@ -1,6 +1,11 @@
 include ../config.mk
+ifeq ($(STATIC), 1)
+LDLIBS = -static -static-libgcc -lm -lstdc++
+CXXFLAGS = -MD -O0 -Wall -std=c++11 -I/usr/local/include
+else
 LDLIBS = -lm -lstdc++
 CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include
+endif
 MXEGCC = /usr/local/src/mxe/usr/bin/i686-pc-mingw32-gcc
 
 all: icepack$(EXE) iceunpack$(EXE)
@@ -32,4 +37,3 @@ clean:
 -include *.d
 
 .PHONY: all install uninstall clean
-

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,7 +1,12 @@
 include ../config.mk
+ifeq ($(STATIC), 1)
+LDLIBS = /usr/lib/x86_64-linux-gnu/libftdi.a /usr/lib/x86_64-linux-gnu/libusb.a /usr/lib/x86_64-linux-gnu/libm.a
+LDFLAGS = -static
+CFLAGS = -MD -O0 -Wall -std=c99 -I/usr/local/include
+else
 LDLIBS = -L/usr/local/lib -lftdi -lm
 CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
-
+endif
 ifeq ($(MXE),1)
 LDLIBS += -lusb
 endif
@@ -26,4 +31,3 @@ clean:
 -include *.d
 
 .PHONY: all install uninstall clean
-

--- a/icetime/Makefile
+++ b/icetime/Makefile
@@ -1,6 +1,11 @@
 include ../config.mk
+ifeq ($(STATIC), 1)
+LDLIBS = -static -static-libgcc -lm -lstdc++
+CXXFLAGS = -MD -O0 -Wall -std=c++11 -I/usr/local/include -DPREFIX='"$(PREFIX)"'
+else
 LDLIBS = -lm -lstdc++
 CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include -DPREFIX='"$(PREFIX)"'
+endif
 
 all: icetime$(EXE)
 
@@ -48,4 +53,3 @@ clean:
 -include *.d
 
 .PHONY: all install uninstall clean
-


### PR DESCRIPTION
Hello,

@Obijuan and I are working to automate the installation and distribution of the Icestorm tools.

In order to be executed on different Linux distributions is useful to compile with static flags. This pull request adds flags to compile icepack, iceprog and icetime static using "make STATIC = 1".

Regards.
