### PR TITLE
Fix iceprog on Windows opening binary in text mode

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -490,7 +490,7 @@ int main(int argc, char **argv)
 		// ---------------------------------------------------------
 
 		FILE *f = (strcmp(filename, "-") == 0) ? stdin :
-			fopen(filename, "r");
+			fopen(filename, "rb");
 		if (f == NULL) {
 			fprintf(stderr, "Error: Can't open '%s' for reading: %s\n", filename, strerror(errno));
 			error();
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
 		if (!read_mode && !check_mode)
 		{
 			FILE *f = (strcmp(filename, "-") == 0) ? stdin :
-				fopen(filename, "r");
+				fopen(filename, "rb");
 			if (f == NULL) {
 				fprintf(stderr, "Error: Can't open '%s' for reading: %s\n", filename, strerror(errno));
 				error();
@@ -599,7 +599,7 @@ int main(int argc, char **argv)
 		if (read_mode)
 		{
 			FILE *f = (strcmp(filename, "-") == 0) ? stdout :
-				fopen(filename, "w");
+				fopen(filename, "wb");
 			if (f == NULL) {
 				fprintf(stderr, "Error: Can't open '%s' for writing: %s\n", filename, strerror(errno));
 				error();
@@ -618,7 +618,7 @@ int main(int argc, char **argv)
 		else
 		{
 			FILE *f = (strcmp(filename, "-") == 0) ? stdin :
-				fopen(filename, "r");
+				fopen(filename, "rb");
 			if (f == NULL) {
 				fprintf(stderr, "Error: Can't open '%s' for reading: %s\n", filename, strerror(errno));
 				error();


### PR DESCRIPTION
This changes iceprog so that it'll open binary files in binary mode, this means that on windows `\n` isn't substituted with `\r\n` and vice versa on reads and writes.