### PR TITLE
Compile with clang++ by default

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
-CXX = clang
+CXX = clang++
 CC = $(CXX)
 PKG_CONFIG = pkg-config
 DESTDIR ?=

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,4 +1,5 @@
 include ../config.mk
+CC = clang
 LDLIBS = -L/usr/local/lib -lm
 CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 
@@ -31,4 +32,3 @@ clean:
 -include *.d
 
 .PHONY: all install uninstall clean
-


### PR DESCRIPTION
Is needed to get icestorm to build with nix.
Edit:
Maybe making clang optional again would be a better solution. https://github.com/NixOS/nixpkgs/pull/15606

Cheers
David