### PR TITLE
Prevent error using STATIC with libftdi1

### DIFF
--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -2,12 +2,14 @@ include ../config.mk
 LDLIBS = -L/usr/local/lib -lm
 CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 
-ifeq ($(STATIC),1)
+NSTATIC = $(shell pkg-config --exists libftdi1 || echo $(STATIC) )
+
+ifeq ($(NSTATIC),1)
 LDFLAGS += -static
-LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --static --libs $$pkg && exit; done; echo -lftdi; )
-CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --static --cflags $$pkg && exit; done; )
+LDLIBS += $(shell for pkg in libftdi; do $(PKG_CONFIG) --silence-errors --static --libs $$pkg && exit; done; )
+CFLAGS += $(shell for pkg in libftdi; do $(PKG_CONFIG) --silence-errors --static --cflags $$pkg && exit; done; )
 else
-LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; echo -lftdi; )
+LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; )
 CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --cflags $$pkg && exit; done; )
 endif
 
@@ -31,4 +33,3 @@ clean:
 -include *.d
 
 .PHONY: all install uninstall clean
-


### PR DESCRIPTION
This commit allows to use general make STATIC=1 without errors because of libftdi1. It simply ignores the STATIC flag when libftdi1-dev is installed.

libftdi1 depends on libusb-1.0

```bash
$ pkg-config --libs libftdi1
-L/usr/local/lib -lftdi1 -lusb-1.0
```

In static mode libusb-1.0 depends on static libudev that is  no longer provided

```bash
$ pkg-config --static --libs libftdi1
-L/usr/local/lib -lftdi1 -lusb-1.0 -ludev -pthread
```

And generates the following error

```bash
$ make STATIC=1
cc -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include -I/usr/local/include/libftdi1 -I/usr/include/libusb-1.0   -c -o iceprog.o iceprog.c
cc -o iceprog -static iceprog.o -L/usr/local/lib -lm -L/usr/local/lib -lftdi1 -lusb-1.0 -ludev -pthread
/usr/bin/ld: cannot find -ludev
collect2: error: ld returned 1 exit status
```

This commit is not a solution to the problem but prevents the build from crash.

A complete solution to reach fully static iceprog using libftdi1 requires to custom build libusb without USE_UDEV flag and link the libusb-1.0.a into iceprog without -ludev flag:

```bash
cc -o iceprog -static iceprog.o -L/usr/local/lib -lm -L/path/to/custom/libusb/lib -lftdi1 -lusb-1.0 -pthread
```

```bash
$ ldd iceprog
	not a dynamic executable
```





