### PR TITLE
Adam D. Horden iceprog makefile osx fix.

### DIFF
--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,17 +1,10 @@
 include ../config.mk
 
-LIBFTDI_VERSION = $(shell $(PKG_CONFIG) --modversion libftdi1 2>/dev/null)
-ifneq ($(LIBFTDI_VERSION),)
-  LIBFTDI_NAME = ftdi1
-else
-  LIBFTDI_NAME = ftdi
-endif
-
-UNAME := $(shell uname -s)
-ifneq ($(UNAME),Darwin)
+ifneq ($(shell uname -s),Darwin)
   LDLIBS = -L/usr/local/lib -lm
   CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 else
+  LIBFTDI_NAME = $(shell $(PKG_CONFIG) --exists libftdi1 && echo ftdi1 || echo ftdi)
   LDLIBS = -L/usr/local/lib -l${LIBFTDI_NAME} -lm
   CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 endif

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,12 +1,19 @@
 include ../config.mk
 
+LIBFTDI_VERSION = $(shell $(PKG_CONFIG) --modversion libftdi1 2>/dev/null)
+ifneq ($(LIBFTDI_VERSION),)
+  LIBFTDI_NAME = ftdi1
+else
+  LIBFTDI_NAME = ftdi
+endif
+
 UNAME := $(shell uname -s)
 ifneq ($(UNAME),Darwin)
   LDLIBS = -L/usr/local/lib -lm
   CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 else
-  LDLIBS = -L/usr/local/lib -L/opt/local/lib -lftdi -lm
-  CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include -I/opt/local/include/
+  LDLIBS = -L/usr/local/lib -l${LIBFTDI_NAME} -lm
+  CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
 endif
 
 ifeq ($(STATIC),1)

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,6 +1,13 @@
 include ../config.mk
-LDLIBS = -L/usr/local/lib -lm
-CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
+
+UNAME := $(shell uname -s)
+ifneq ($(UNAME),Darwin)
+  LDLIBS = -L/usr/local/lib -lm
+  CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
+else
+  LDLIBS = -L/usr/local/lib -L/opt/local/lib -lftdi -lm
+  CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include -I/opt/local/include/
+endif
 
 ifeq ($(STATIC),1)
 LDFLAGS += -static


### PR DESCRIPTION
Fix to enable a clean build on Mac OS X.

iceprog would fail to compile as it could not find the header ftdi.h.

The fix will check to see if you are compiling on Mac OS X and set the correct LDLIBS and CFLAGS for Mac OS X.

This attempts to detect the correct version of the FTDI headers and sets the correct CFLAGS for the version of the FTDI headers installed.

This is a first pass and has been tested. It also only applies if uname -s is equal to Darwin. I have tested to ensure this still compiles correctly on Linux.

brew install libftdi is the common way to install libfdti on Mac OS X. #