### PR TITLE
Added a new config variable CHIPDB_SUBDIR.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -3,6 +3,7 @@ CC ?= $(CXX)
 PKG_CONFIG ?= pkg-config
 DESTDIR ?=
 PREFIX ?= /usr/local
+CHIPDB_SUBDIR ?= icebox
 
 ifeq ($(MXE),1)
 EXE = .exe

--- a/icetime/Makefile
+++ b/icetime/Makefile
@@ -1,6 +1,6 @@
 include ../config.mk
 LDLIBS = -lm -lstdc++
-CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include -DPREFIX='"$(PREFIX)"'
+CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include -DPREFIX='"$(PREFIX)"' -DCHIPDB_SUBDIR='"$(CHIPDB_SUBDIR)"'
 
 ifeq ($(STATIC),1)
 LDFLAGS += -static

--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -295,9 +295,9 @@ void read_chipdb()
 #else
 		homedir += getenv("HOME");
 #endif
-		snprintf(buffer, 1024, "%s%s/share/icebox/chipdb-%s.txt", homedir.c_str(), PREFIX+1, config_device.c_str());
+		snprintf(buffer, 1024, "%s%s/share/" CHIPDB_SUBDIR "/chipdb-%s.txt", homedir.c_str(), PREFIX+1, config_device.c_str());
 	} else
-		snprintf(buffer, 1024, "%s/share/icebox/chipdb-%s.txt", PREFIX, config_device.c_str());
+		snprintf(buffer, 1024, PREFIX "/share/" CHIPDB_SUBDIR "/chipdb-%s.txt", config_device.c_str());
 
 	FILE *fdb = fopen(buffer, "r");
 	if (fdb == nullptr) {


### PR DESCRIPTION
 It determines the subdir name
used in $(PREFIX)/share/ to install the chip database. This provides a
mechanism to choose a directory different than icebox (default).
I.e. fpga-icestorm/chipdb for Debian.