### PR TITLE
Fix for Win32 builds

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -8,5 +8,6 @@ CHIPDB_SUBDIR ?= icebox
 ifeq ($(MXE),1)
 EXE = .exe
 CXX = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc
+CC ?= $(CXX)
 PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config
 endif

--- a/config.mk
+++ b/config.mk
@@ -8,6 +8,6 @@ CHIPDB_SUBDIR ?= icebox
 ifeq ($(MXE),1)
 EXE = .exe
 CXX = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-gcc
-CC ?= $(CXX)
+CC = $(CXX)
 PKG_CONFIG = /usr/local/src/mxe/usr/bin/i686-w64-mingw32.static-pkg-config
 endif


### PR DESCRIPTION
Please see https://github.com/udif/cae-win-tools
I have forked 3 repositories only due to Win32 cross compile issues (icestorm, yosis, icarus), and if this pull request is accepted I could remove the icestorm fork.
