### PR TITLE
Fix latency timer

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -454,6 +454,11 @@ int main(int argc, char **argv)
 		error();
 	}
 
+	if (ftdi_set_latency_timer(&ftdic, 2) < 0) {
+		fprintf(stderr, "Failed to set latency timer (%s).\n", ftdi_get_error_string(&ftdic));
+		error();
+	}
+
 	if (ftdi_set_bitmode(&ftdic, 0xff, BITMODE_MPSSE) < 0) {
 		fprintf(stderr, "Failed set BITMODE_MPSSE on iCE FTDI USB device.\n");
 		error();


### PR DESCRIPTION
The timer latency affects iceprog performance. A value of 16 makes it 5 times slower.
Old kernels have the "low_latency" enabled for this module, so we don't need it.
The cost is 1 kHz interrupts while the device is opened.
New kernel versions are setting more conservative value (16). This relaxes the system (62,5 Hz interrupts) but makes the transfer much slower.
This patch adds a call to ftdi_set_latency_timer to set its value to its optimal (2 => 500 Hz interrupts)
Other projects using SPI on the FTDI also does it. I took the idea from flashrom.