### PR TITLE
icetime: allow longer lines in input asc files

### DIFF
--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -208,11 +208,19 @@ void read_pcf(const char *filename)
 
 void read_config()
 {
-	char buffer[128];
+	constexpr size_t line_buf_size = 65536;
+	char buffer[line_buf_size];
 	int tile_x, tile_y, line_nr = -1;
 
-	while (fgets(buffer, 128, fin))
+	while (fgets(buffer, line_buf_size, fin))
 	{
+		if (buffer[strlen(buffer) - 1] != '\n')
+		{
+			fprintf(stderr, "Input file contains very long lines.\n");
+			fprintf(stderr, "icetime cannot process it.\n");
+			exit(1);
+		}
+
 		if (buffer[0] == '.')
 		{
 			line_nr = -1;


### PR DESCRIPTION
icetime was reading the asc configuration file using a 128-byte line
buffer -- which is usually fine, but can cause it to truncate the names
of nets given in .sym lines if those names are very, very long.

Long net names like this can arise in deeply hierarchical designs,
particularly if there's a code generator involved.

This change expands the line buffer to 1024 bytes.

**Discussion:** this leaves a subtle bug, but its fix will be slightly more invasive, so I wanted to propose this simple fix first and start the discussion.

If icetime encounters a config line longer than this constant minus 1 (here 1023 bytes or more) it will get the latter portion of the line from the *next* fgets call and interpret it as a second line.  If the latter portion happens to begin with, say, `.sym` or `.io_tile`, weird things will happen.

My default fix would be to read into a `std::string` without a fixed length limit, but I notice you've been consistent in using C file I/O operations and I suspect it's for a  reason (like minimizing heap allocations during the parsing loop).

Backup fix: warn the user, or fail, when the buffer returned by `fgets` is not terminated by a newline.