### PR TITLE
Update PLL DIVF range to be [0,127]

### DIFF
--- a/icepll/icepll.cc
+++ b/icepll/icepll.cc
@@ -108,6 +108,15 @@ int main(int argc, char **argv)
 	int best_divf = 0;
 	int best_divq = 0;
 
+	//The documentation in the iCE40 PLL Usage Guide incorrectly lists the
+	//maximum value of DIVF as 63, when it is only limited to 63 when using
+	//feedback modes other that SIMPLE.
+	int divf_max = 63;
+	if(simple_feedback)
+	{
+		divf_max = 127;
+	}
+
 	if (f_pllin < 10 || f_pllin > 133) {
 		fprintf(stderr, "Error: PLL input frequency %.3f MHz is outside range 10 MHz - 133 MHz!\n", f_pllin);
 		exit(1);
@@ -123,7 +132,7 @@ int main(int argc, char **argv)
 		double f_pfd = f_pllin / (divr + 1);
 		if (f_pfd < 10 || f_pfd > 133) continue;
 
-		for (int divf = 0; divf <= 63; divf++)
+		for (int divf = 0; divf <= divf_max; divf++)
 		{
 			if (simple_feedback)
 			{


### PR DESCRIPTION
As discussed in issue #83, the range of the DIVF parameter in the
iCE40 PLL Usage Guide is incorrectly listed as being 0-63, when it
should actually be 0-127 when used in the SIMPLE feedback mode. It 
is still restricted to 0-63 in other modes however.