### PR TITLE
Make install target work for Windows

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,8 +1,8 @@
 CXX ?= clang++
 CC ?= clang
 LDLIBS = -lm -lstdc++
-CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
-CXXFLAGS = -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include
+CFLAGS += -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
+CXXFLAGS += -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include
 PKG_CONFIG ?= pkg-config
 DESTDIR ?=
 PREFIX ?= /usr/local

--- a/icebox/Makefile
+++ b/icebox/Makefile
@@ -26,26 +26,26 @@ install: all
 	cp chipdb-8k.txt     $(DESTDIR)$(PREFIX)/share/icebox/
 	cp icebox.py         $(DESTDIR)$(PREFIX)/bin/icebox.py
 	cp iceboxdb.py       $(DESTDIR)$(PREFIX)/bin/iceboxdb.py
-	cp icebox_chipdb.py  $(DESTDIR)$(PREFIX)/bin/icebox_chipdb
-	cp icebox_diff.py    $(DESTDIR)$(PREFIX)/bin/icebox_diff
-	cp icebox_explain.py $(DESTDIR)$(PREFIX)/bin/icebox_explain
-	cp icebox_colbuf.py  $(DESTDIR)$(PREFIX)/bin/icebox_colbuf
-	cp icebox_html.py    $(DESTDIR)$(PREFIX)/bin/icebox_html
-	cp icebox_maps.py    $(DESTDIR)$(PREFIX)/bin/icebox_maps
-	cp icebox_vlog.py    $(DESTDIR)$(PREFIX)/bin/icebox_vlog
-	cp icebox_stat.py    $(DESTDIR)$(PREFIX)/bin/icebox_stat
+	cp icebox_chipdb.py  $(DESTDIR)$(PREFIX)/bin/icebox_chipdb$(PY_EXE)
+	cp icebox_diff.py    $(DESTDIR)$(PREFIX)/bin/icebox_diff$(PY_EXE)
+	cp icebox_explain.py $(DESTDIR)$(PREFIX)/bin/icebox_explain$(PY_EXE)
+	cp icebox_colbuf.py  $(DESTDIR)$(PREFIX)/bin/icebox_colbuf$(PY_EXE)
+	cp icebox_html.py    $(DESTDIR)$(PREFIX)/bin/icebox_html$(PY_EXE)
+	cp icebox_maps.py    $(DESTDIR)$(PREFIX)/bin/icebox_maps$(PY_EXE)
+	cp icebox_vlog.py    $(DESTDIR)$(PREFIX)/bin/icebox_vlog$(PY_EXE)
+	cp icebox_stat.py    $(DESTDIR)$(PREFIX)/bin/icebox_stat$(PY_EXE)
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/icebox.py
 	rm -f $(DESTDIR)$(PREFIX)/bin/iceboxdb.py
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_chipdb
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_diff
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_explain
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_colbuf
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_html
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_maps
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_vlog
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_stat
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_chipdb$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_diff$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_explain$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_colbuf$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_html$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_maps$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_vlog$(PY_EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebox_stat$(PY_EXE)
 	rm -f $(DESTDIR)$(PREFIX)/share/icebox/chipdb-384.txt
 	rm -f $(DESTDIR)$(PREFIX)/share/icebox/chipdb-1k.txt
 	rm -f $(DESTDIR)$(PREFIX)/share/icebox/chipdb-8k.txt

--- a/icebram/Makefile
+++ b/icebram/Makefile
@@ -14,10 +14,10 @@ test: icebram
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp icebram $(DESTDIR)$(PREFIX)/bin/icebram
+	cp icebram$(EXE) $(DESTDIR)$(PREFIX)/bin/icebram$(EXE)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/icebram
+	rm -f $(DESTDIR)$(PREFIX)/bin/icebram$(EXE)
 
 clean:
 	rm -f icebram

--- a/icemulti/Makefile
+++ b/icemulti/Makefile
@@ -11,10 +11,10 @@ icemulti$(EXE): icemulti.o
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp icemulti $(DESTDIR)$(PREFIX)/bin/icemulti
+	cp icemulti$(EXE) $(DESTDIR)$(PREFIX)/bin/icemulti$(EXE)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/icemulti
+	rm -f $(DESTDIR)$(PREFIX)/bin/icemulti$(EXE)
 
 clean:
 	rm -f icemulti

--- a/icepack/Makefile
+++ b/icepack/Makefile
@@ -18,12 +18,12 @@ iceunpack.exe:
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp icepack $(DESTDIR)$(PREFIX)/bin/icepack
-	ln -sf icepack $(DESTDIR)$(PREFIX)/bin/iceunpack
+	cp icepack$(EXE) $(DESTDIR)$(PREFIX)/bin/icepack$(EXE)
+	ln -sf icepack$(EXE) $(DESTDIR)$(PREFIX)/bin/iceunpack$(EXE)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/icepack
-	rm -f $(DESTDIR)$(PREFIX)/bin/iceunpack
+	rm -f $(DESTDIR)$(PREFIX)/bin/icepack$(EXE)
+	rm -f $(DESTDIR)$(PREFIX)/bin/iceunpack$(EXE)
 
 clean:
 	rm -f icepack

--- a/icepll/Makefile
+++ b/icepll/Makefile
@@ -11,10 +11,10 @@ icepll$(EXE): icepll.o
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp icepll $(DESTDIR)$(PREFIX)/bin/icepll
+	cp icepll$(EXE) $(DESTDIR)$(PREFIX)/bin/icepll$(EXE)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/icepll
+	rm -f $(DESTDIR)$(PREFIX)/bin/icepll$(EXE)
 
 clean:
 	rm -f icepll

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -23,12 +23,12 @@ iceprog$(EXE): iceprog.o
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp iceprog $(DESTDIR)$(PREFIX)/bin/iceprog
+	cp iceprog$(EXE) $(DESTDIR)$(PREFIX)/bin/iceprog$(EXE)
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
 	install -c -m 644 iceprog.1 $(DESTDIR)$(PREFIX)/share/man/man1
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/iceprog
+	rm -f $(DESTDIR)$(PREFIX)/bin/iceprog$(EXE)
 	rm -f $(DESTDIR)$(PREFIX)/share/man/man1/iceprog.1
 
 clean:

--- a/icetime/Makefile
+++ b/icetime/Makefile
@@ -19,10 +19,10 @@ timings.inc: timings.py ../icefuzz/timings_*.txt
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp icetime $(DESTDIR)$(PREFIX)/bin/icetime
+	cp icetime$(EXE) $(DESTDIR)$(PREFIX)/bin/icetime$(EXE)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/icetime
+	rm -f $(DESTDIR)$(PREFIX)/bin/icetime$(EXE)
 
 
 # View timing netlist:


### PR DESCRIPTION
I would like to change the install target so that it can be used on Windows as well as other platforms. This mostly consisted of making the install target honor `$(EXE)`. For the Python scripts in icebox, I added a new `$(PY_EXE)` variable to control the suffix of the Python scripts.

This PR does _not_ delete the existing MXE special case. That has been kept.

This is part of the bikeshed in issue #86.