### PR TITLE
icebox: Preserve extra bits when writing to file

### DIFF
--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -690,6 +690,8 @@ class iceconfig:
                 print(".ram_data %d %d" % (x, y), file=f)
                 for line in self.ram_data[(x, y)]:
                     print(line, file=f)
+            for extra_bit in sorted(self.extra_bits):
+                print(".extra_bit %d %d %d" % extra_bit, file=f)
 
 class tileconfig:
     def __init__(self, tile):


### PR DESCRIPTION
Extra bits are read from a file, but they aren't written back.

This patch adds the missing code so they are included in the output.