### PR TITLE
modularized standard Makefile config

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,11 +1,19 @@
+PREFIX ?= /usr/local
+
 CXX ?= clang++
 CC ?= clang
-LDLIBS = -lm -lstdc++
-CFLAGS += -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include
-CXXFLAGS += -MD -O0 -ggdb -Wall -std=c++11 -I/usr/local/include
 PKG_CONFIG ?= pkg-config
+
+C_STD ?= c99
+CXX_STD ?= c++11
+OPT_LEVEL ?= 0
+WARN_LEVEL ?= all
+
+LDLIBS = -lm -lstdc++
+CFLAGS += -MD -O$(OPT_LEVEL) -ggdb -W$(WARN_LEVEL) -std=$(C_STD) -I$(PREFIX)/include
+CXXFLAGS += -MD -O$(OPT_LEVEL) -ggdb -W$(WARN_LEVEL) -std=$(CXX_STD) -I$(PREFIX)/include
+
 DESTDIR ?=
-PREFIX ?= /usr/local
 CHIPDB_SUBDIR ?= icebox
 
 ifeq ($(MXE),1)


### PR DESCRIPTION
This makes it a bit easier to package icestorm for distros, because PREFIX can
be set in one place without having to patch the config.mk in the package build
processes.

The C and C++ standard, optimization and warning level modularization were just
collateral benefit.