### PR TITLE
`icemulti' error checks and argument handling

### DIFF
--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -194,6 +195,8 @@ void usage()
 
 int main(int argc, char **argv)
 {
+    int c;
+    char *endptr = NULL;
     bool coldboot = false;
     int por_image = 0;
     int image_count = 0;
@@ -203,51 +206,62 @@ int main(int argc, char **argv)
     std::unique_ptr<Image> images[NUM_IMAGES];
     const char *outfile_name = NULL;
 
+    static struct option long_options[] = {
+        {NULL, 0, NULL, 0}
+    };
+
     program_short_name = strrchr(argv[0], '/');
     if (program_short_name == NULL)
         program_short_name = argv[0];
     else
         program_short_name++;
 
-    for (int i = 1; i < argc; i++)
-    {
-	if (argv[i][0] == '-' && argv[i][1]) {
-            for (int j = 1; argv[i][j]; j++)
-                if (argv[i][j] == 'c') {
-                    coldboot = true;
-                } else if (argv[i][j] == 'p' && argv[i][j+1]) {
-                    por_image = argv[i][++j] - '0';
-                } else if (argv[i][j] == 'a' || argv[i][j] == 'A') {
-                    align_first = argv[i][j] == 'A';
-                    if (argv[i][j+1])
-                        align_bits = atoi(&argv[i][j+1]);
-                    else if(i+1 < argc)
-                        align_bits = atoi(argv[++i]);
-                    else
-                        usage();
-                    break;
-                } else if (argv[i][j] == 'o') {
-                    if (argv[i][j+1])
-                        outfile_name = &argv[i][j+1];
-                    else if(i+1 < argc)
-                        outfile_name = argv[++i];
-                    else
-                        usage();
-                    break;
-                } else if (argv[i][j] == 'v') {
-                    log_level++;
-                } else
-                    usage();
-            continue;
+    while ((c = getopt_long(argc, argv, "cp:a:A:o:v",
+                long_options, NULL)) != -1)
+        switch (c) {
+            case 'c':
+                coldboot = true;
+                break;
+            case 'p':
+                if (optarg[0] == '0' && optarg[1] == '\0')
+                    por_image = 0;
+                else if (optarg[0] == '1' && optarg[1] == '\0')
+                    por_image = 1;
+                else if (optarg[0] == '2' && optarg[1] == '\0')
+                    por_image = 2;
+                else if (optarg[0] == '3' && optarg[1] == '\0')
+                    por_image = 3;
+                else
+                    error("`%s' is not a valid power-on/reset image (must be 0, 1, 2, or 3)\n", optarg);
+                break;
+            case 'A':
+                align_first = true;
+                /* fallthrough */
+            case 'a':
+                align_bits = strtol(optarg, &endptr, 0);
+                if (*endptr != '\0')
+                    error("`%s' is not a valid number\n", optarg);
+                break;
+            case 'o':
+                outfile_name = optarg;
+                break;
+            case 'v':
+                log_level++;
+                break;
+            default:
+                usage();
         }
 
-        if (image_count >= NUM_IMAGES)
-            error("Too many images supplied\n");
-        images[image_count++].reset(new Image(argv[i]));
+    if (optind == argc) {
+        fprintf(stderr, "%s: missing argument\n", program_short_name);
+        usage();
     }
 
-    if (!image_count)
-        usage();
+    while (optind != argc) {
+        if (image_count >= NUM_IMAGES)
+            error("Too many images supplied\n");
+        images[image_count++].reset(new Image(argv[optind++]));
+    }
 
     if (coldboot && por_image != 0)
         error("Can't select power on reset boot image in cold boot mode\n");

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -24,7 +24,7 @@
 
 #define log(...) fprintf(stderr, __VA_ARGS__);
 #define info(...) do { if (log_level > 0) fprintf(stderr, __VA_ARGS__); } while (0)
-#define error(...) do { fprintf(stderr, "Error: " __VA_ARGS__); exit(1); } while (0)
+#define error(...) do { fprintf(stderr, "Error: " __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
 
 int log_level = 0;
 
@@ -173,7 +173,7 @@ void usage()
     log(" -v\n");
     log(" verbose (repeat to increase verbosity)\n");
     log("\n");
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 int main(int argc, char **argv)
@@ -278,5 +278,5 @@ int main(int argc, char **argv)
     }
 
     info("Done.\n");
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -241,6 +241,8 @@ int main(int argc, char **argv)
                 align_bits = strtol(optarg, &endptr, 0);
                 if (*endptr != '\0')
                     error("`%s' is not a valid number\n", optarg);
+                if (align_bits < 0)
+                    error("argument to `-%c' must be non-negative\n", c);
                 break;
             case 'o':
                 outfile_name = optarg;

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -21,10 +21,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define log(...) fprintf(stderr, __VA_ARGS__);
 #define info(...) do { if (log_level > 0) fprintf(stderr, __VA_ARGS__); } while (0)
-#define error(...) do { fprintf(stderr, "Error: " __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
+#define error(...) do { fprintf(stderr, "%s: ", program_short_name); fprintf(stderr, __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
+
+static char *program_short_name;
 
 int log_level = 0;
 
@@ -186,6 +189,12 @@ int main(int argc, char **argv)
     Header headers[NUM_HEADERS];
     std::unique_ptr<Image> images[NUM_IMAGES];
     const char *outfile_name = NULL;
+
+    program_short_name = strrchr(argv[0], '/');
+    if (program_short_name == NULL)
+        program_short_name = argv[0];
+    else
+        program_short_name++;
 
     for (int i = 1; i < argc; i++)
     {

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -109,6 +109,9 @@ size_t Image::size()
     ifs.seekg (0, ifs.beg);
     if (ifs.fail())
         error("can't seek on input image `%s': %s\n", filename, strerror(errno));
+
+    if (length == 0)
+        error("input image `%s' doesn't contain any data\n", filename);
     return length;
 }
 

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -87,19 +87,28 @@ class Image {
     uint32_t offs;
 
 public:
-    Image(const char *filename) : filename(filename), ifs(filename, std::ifstream::binary) {}
-
+    Image(const char *filename);
     size_t size();
     void write(std::ostream &ofs, uint32_t &file_offset);
     void place(uint32_t o) { offs = o; }
     uint32_t offset() const { return offs; }
 };
 
+Image::Image(const char *filename) : filename(filename), ifs(filename, std::ifstream::binary)
+{
+    if (ifs.fail())
+        error("can't open input image `%s': %s\n", filename, strerror(errno));
+}
+
 size_t Image::size()
 {
     ifs.seekg (0, ifs.end);
+    if (ifs.fail())
+        error("can't seek on input image `%s': %s\n", filename, strerror(errno));
     size_t length = ifs.tellg();
     ifs.seekg (0, ifs.beg);
+    if (ifs.fail())
+        error("can't seek on input image `%s': %s\n", filename, strerror(errno));
     return length;
 }
 


### PR DESCRIPTION
Since pull request #92 doesn't appear to make any progress, I'm creating a pull request for the next part of the `icemulti` changes without a test suite. This pull request introduces the `getopt` library for parsing command-line arguments, adds some missing error checks (for missing or empty input files and I/O errors) and provides more information with the existing error checks (program and file name).