### PR TITLE
Add support for non-warmboot images

### DIFF
--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -26,6 +26,7 @@ class iceconfig:
         self.max_x = 0
         self.max_y = 0
         self.device = ""
+        self.warmboot = True
         self.logic_tiles = dict()
         self.io_tiles = dict()
         self.ramb_tiles = dict()
@@ -668,6 +669,10 @@ class iceconfig:
                     assert line[1] in ["1k", "5k", "8k", "384"]
                     self.device = line[1]
                     continue
+                if line[0] == ".warmboot":
+                    assert line[1] in ["disabled", "enabled"]
+                    self.warmboot = line[1] == "enabled"
+                    continue
                 if line[0] == ".sym":
                     self.symbols.setdefault(int(line[1]), set()).add(line[2])
                     continue
@@ -680,6 +685,8 @@ class iceconfig:
     def write_file(self, filename):
         with open(filename, "w") as f:
             print(".device %s" % self.device, file=f)
+            if not self.warmboot:
+                print(".warmboot disabled", file=f)
             for y in range(self.max_y+1):
                 for x in range(self.max_x+1):
                     if self.tile_pos(x, y) is not None:

--- a/icepack/icepack.cc
+++ b/icepack/icepack.cc
@@ -649,6 +649,18 @@ void FpgaConfig::read_ascii(std::istream &ifs)
 			continue;
 		}
 
+		if (command == ".warmboot")
+		{
+			is >> this->warmboot;
+
+			if (this->warmboot != "disabled" &&
+			    this->warmboot != "enabled")
+				error("Unknown warmboot setting '%s'.\n",
+				      this->warmboot.c_str());
+
+			continue;
+		}
+
 		if (command == ".io_tile" || command == ".logic_tile" || command == ".ramb_tile" || command == ".ramt_tile")
 		{
 			if (!got_device)
@@ -764,6 +776,8 @@ void FpgaConfig::write_ascii(std::ostream &ofs) const
 	}
 
 	ofs << stringf("\n.device %s\n", this->device.c_str());
+	if (this->warmboot != "enabled")
+		ofs << stringf(".warmboot %s\n", this->warmboot.c_str());
 
 	typedef std::tuple<int, int, int> tile_bit_t;
 	std::set<tile_bit_t> tile_bits;


### PR DESCRIPTION
This pull request allows the “warmboot” bit of a configuration image to be preserved in a `.bin` → `.asc` → `.bin` round-trip.

It extends the `.asc` bitstream format in a way that allows it to represent a configuration image with the “warmboot” feature disabled by adding the following two statements to the syntax:

    .warmboot disabled
    .warmboot enabled

The `.warmboot` statement is only included in the output if the “warmboot” feature is disabled, and the default is to assume that the feature is enabled, so this change should be compatible with existing code.