### PR TITLE
icemulti: Re-use images

### DIFF
--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -248,7 +248,9 @@ int main(int argc, char **argv)
     while (optind != argc) {
         if (image_count >= NUM_IMAGES)
             error("Too many images supplied\n");
-        images[image_count++].reset(new Image(argv[optind++]));
+        images[image_count].reset(new Image(argv[optind++]));
+        header_images[image_count + 1] = &*images[image_count];
+        image_count++;
     }
 
     if (coldboot && por_image != 0)
@@ -269,8 +271,6 @@ int main(int argc, char **argv)
     }
 
     // Populate headers
-    for (int i=0; i<image_count; i++)
-        header_images[i + 1] = &*images[i];
     header_images[0] = header_images[por_image + 1];
     for (int i=image_count; i < NUM_IMAGES; i++)
         header_images[i + 1] = header_images[0];

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -124,10 +124,10 @@ void Image::write(std::ostream &ofs, uint32_t &file_offset)
 class Header {
 public:
     Image const *image;
-    void write(std::ostream &ofs, uint32_t &file_offset, bool coldboot);
 };
 
-void Header::write(std::ostream &ofs, uint32_t &file_offset, bool coldboot)
+static void write_header(std::ostream &ofs, uint32_t &file_offset,
+                         Image const *image, bool coldboot)
 {
     // Preamble
     write_byte(ofs, file_offset, 0x7e);
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
     for (int i=0; i<NUM_HEADERS; i++)
     {
         pad_to(*osp, file_offset, i * HEADER_SIZE);
-        headers[i].write(*osp, file_offset, i == 0 && coldboot);
+        write_header(*osp, file_offset, headers[i].image, i == 0 && coldboot);
     }
     for (int i=0; i<image_count; i++)
     {

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
     int image_count = 0;
     int align_bits = 0;
     bool align_first = false;
-    Image *header_images[NUM_HEADERS];
+    Image *header_images[NUM_IMAGES];
     std::unique_ptr<Image> images[NUM_IMAGES];
     const char *outfile_name = NULL;
 
@@ -250,7 +250,7 @@ int main(int argc, char **argv)
         if (header_count >= NUM_IMAGES)
             error("Too many images supplied\n");
         images[image_count].reset(new Image(argv[optind++]));
-        header_images[header_count + 1] = &*images[image_count];
+        header_images[header_count] = &*images[image_count];
         header_count++;
         image_count++;
     }
@@ -273,9 +273,8 @@ int main(int argc, char **argv)
     }
 
     // Populate headers
-    header_images[0] = header_images[por_image + 1];
     for (int i=header_count; i < NUM_IMAGES; i++)
-        header_images[i + 1] = header_images[0];
+        header_images[i] = header_images[por_image];
 
     std::ofstream ofs;
     std::ostream *osp;
@@ -293,7 +292,10 @@ int main(int argc, char **argv)
     for (int i=0; i<NUM_HEADERS; i++)
     {
         pad_to(*osp, file_offset, i * HEADER_SIZE);
-        write_header(*osp, file_offset, header_images[i], i == 0 && coldboot);
+        if (i == 0)
+            write_header(*osp, file_offset, header_images[por_image], coldboot);
+        else
+            write_header(*osp, file_offset, header_images[i - 1], false);
     }
     for (int i=0; i<image_count; i++)
     {

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -123,19 +123,15 @@ void Image::write(std::ostream &ofs, uint32_t &file_offset)
 
 class Header {
     uint32_t image_offs;
-    bool empty;
 public:
-    Header() : empty(true) {}
+    Header() {}
     Header(const Image &i) :
-        image_offs(i.offset()), empty(false) {}
+        image_offs(i.offset()) {}
     void write(std::ostream &ofs, uint32_t &file_offset, bool coldboot);
 };
 
 void Header::write(std::ostream &ofs, uint32_t &file_offset, bool coldboot)
 {
-    if (empty)
-        return;
-
     // Preamble
     write_byte(ofs, file_offset, 0x7e);
     write_byte(ofs, file_offset, 0xaa);

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -79,11 +79,12 @@ static void pad_to(std::ostream &ofs, uint32_t &file_offset, uint32_t target)
 }
 
 class Image {
-    const char *filename;
     std::ifstream ifs;
     uint32_t offs;
 
 public:
+    const char *const filename;
+
     Image(const char *filename);
     size_t size();
     void write(std::ostream &ofs, uint32_t &file_offset);
@@ -91,7 +92,7 @@ public:
     uint32_t offset() const { return offs; }
 };
 
-Image::Image(const char *filename) : filename(filename), ifs(filename, std::ifstream::binary)
+Image::Image(const char *filename) : ifs(filename, std::ifstream::binary), filename(filename)
 {
     if (ifs.fail())
         error("can't open input image `%s': %s\n", filename, strerror(errno));
@@ -267,7 +268,7 @@ int main(int argc, char **argv)
         offs += images[i]->size();
         align_offset(offs, align_bits);
         if (print_offsets)
-            fprintf(stderr, "Place image %d at %06x .. %06x.\n", i, int(images[i]->offset()), int(offs));
+            fprintf(stderr, "Place image %d at %06x .. %06x (`%s')\n", i, int(images[i]->offset()), int(offs), images[i]->filename);
     }
 
     // Populate headers

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -122,11 +122,8 @@ void Image::write(std::ostream &ofs, uint32_t &file_offset)
 }
 
 class Header {
-    uint32_t image_offs;
 public:
-    Header() {}
-    Header(const Image &i) :
-        image_offs(i.offset()) {}
+    Image const *image;
     void write(std::ostream &ofs, uint32_t &file_offset, bool coldboot);
 };
 
@@ -146,9 +143,9 @@ void Header::write(std::ostream &ofs, uint32_t &file_offset, bool coldboot)
     // Boot address
     write_byte(ofs, file_offset, 0x44);
     write_byte(ofs, file_offset, 0x03);
-    write_byte(ofs, file_offset, (image_offs >> 16) & 0xff);
-    write_byte(ofs, file_offset, (image_offs >> 8) & 0xff);
-    write_byte(ofs, file_offset, image_offs & 0xff);
+    write_byte(ofs, file_offset, (image->offset() >> 16) & 0xff);
+    write_byte(ofs, file_offset, (image->offset() >> 8) & 0xff);
+    write_byte(ofs, file_offset, image->offset() & 0xff);
 
     // Bank offset
     write_byte(ofs, file_offset, 0x82);
@@ -278,10 +275,10 @@ int main(int argc, char **argv)
 
     // Populate headers
     for (int i=0; i<image_count; i++)
-        headers[i + 1] = Header(*images[i]);
-    headers[0] = headers[por_image + 1];
+        headers[i + 1].image = &*images[i];
+    headers[0].image = headers[por_image + 1].image;
     for (int i=image_count; i < NUM_IMAGES; i++)
-        headers[i + 1] = headers[0];
+        headers[i + 1].image = headers[0].image;
 
     std::ofstream ofs;
     std::ostream *osp;

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -33,7 +33,6 @@ static char *program_short_name;
 int log_level = 0;
 
 static const int NUM_IMAGES = 4;
-static const int NUM_HEADERS = NUM_IMAGES + 1;
 static const int HEADER_SIZE = 32;
 
 static void align_offset(uint32_t &offset, int bits)
@@ -262,7 +261,7 @@ int main(int argc, char **argv)
         error("Specified non-existing image for power on reset\n");
 
     // Place images
-    uint32_t offs = NUM_HEADERS * HEADER_SIZE;
+    uint32_t offs = (NUM_IMAGES + 1) * HEADER_SIZE;
     if (align_first)
         align_offset(offs, align_bits);
     for (int i=0; i<image_count; i++) {
@@ -289,7 +288,7 @@ int main(int argc, char **argv)
     }
 
     uint32_t file_offset = 0;
-    for (int i=0; i<NUM_HEADERS; i++)
+    for (int i=0; i<NUM_IMAGES + 1; i++)
     {
         pad_to(*osp, file_offset, i * HEADER_SIZE);
         if (i == 0)

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -247,10 +247,18 @@ int main(int argc, char **argv)
     while (optind != argc) {
         if (header_count >= NUM_IMAGES)
             error("Too many images supplied\n");
-        images[image_count].reset(new Image(argv[optind++]));
+        for (int i = 0; i < image_count; i++)
+            if (strcmp(argv[optind], images[i]->filename) == 0) {
+                header_images[header_count] = &*images[i];
+                goto image_found;
+            }
+        images[image_count].reset(new Image(argv[optind]));
         header_images[header_count] = &*images[image_count];
-        header_count++;
         image_count++;
+
+    image_found:
+        header_count++;
+        optind++;
     }
 
     if (coldboot && por_image != 0)

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -185,6 +185,7 @@ int main(int argc, char **argv)
     char *endptr = NULL;
     bool coldboot = false;
     int por_image = 0;
+    int header_count = 0;
     int image_count = 0;
     int align_bits = 0;
     bool align_first = false;
@@ -246,17 +247,18 @@ int main(int argc, char **argv)
     }
 
     while (optind != argc) {
-        if (image_count >= NUM_IMAGES)
+        if (header_count >= NUM_IMAGES)
             error("Too many images supplied\n");
         images[image_count].reset(new Image(argv[optind++]));
-        header_images[image_count + 1] = &*images[image_count];
+        header_images[header_count + 1] = &*images[image_count];
+        header_count++;
         image_count++;
     }
 
     if (coldboot && por_image != 0)
         error("Can't select power on reset boot image in cold boot mode\n");
 
-    if (por_image >= image_count)
+    if (por_image >= header_count)
         error("Specified non-existing image for power on reset\n");
 
     // Place images
@@ -272,7 +274,7 @@ int main(int argc, char **argv)
 
     // Populate headers
     header_images[0] = header_images[por_image + 1];
-    for (int i=image_count; i < NUM_IMAGES; i++)
+    for (int i=header_count; i < NUM_IMAGES; i++)
         header_images[i + 1] = header_images[0];
 
     std::ofstream ofs;

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -25,12 +25,9 @@
 #include <string.h>
 
 #define log(...) fprintf(stderr, __VA_ARGS__);
-#define info(...) do { if (log_level > 0) fprintf(stderr, __VA_ARGS__); } while (0)
 #define error(...) do { fprintf(stderr, "%s: ", program_short_name); fprintf(stderr, __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
 
 static char *program_short_name;
-
-int log_level = 0;
 
 static const int NUM_IMAGES = 4;
 static const int HEADER_SIZE = 32;
@@ -191,6 +188,7 @@ int main(int argc, char **argv)
     Image *header_images[NUM_IMAGES];
     std::unique_ptr<Image> images[NUM_IMAGES];
     const char *outfile_name = NULL;
+    bool print_offsets = false;
 
     static struct option long_options[] = {
         {NULL, 0, NULL, 0}
@@ -234,7 +232,7 @@ int main(int argc, char **argv)
                 outfile_name = optarg;
                 break;
             case 'v':
-                log_level++;
+                print_offsets = true;
                 break;
             default:
                 usage();
@@ -268,7 +266,8 @@ int main(int argc, char **argv)
         images[i]->place(offs);
         offs += images[i]->size();
         align_offset(offs, align_bits);
-        info("Place image %d at %06x .. %06x.\n", i, int(images[i]->offset()), int(offs));
+        if (print_offsets)
+            fprintf(stderr, "Place image %d at %06x .. %06x.\n", i, int(images[i]->offset()), int(offs));
     }
 
     // Populate headers
@@ -302,6 +301,5 @@ int main(int argc, char **argv)
         images[i]->write(*osp, file_offset);
     }
 
-    info("Done.\n");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is the fourth part of the changes suggested in pull request #90. It causes `icemulti` to include input files listed on the command line only once in the output file, regardless of whether they have been specified explicitly by file name or implicitly using `-p` / as default.

Up to now, `icemulti` included the input files listed on the command line exactly in that order in the output file. The power-on/reset header and, if less than four input files have been specified, the remaining headers point to the input file to be used on power-on/reset (usually the first one).

Normally, the input files are different from each other, so this is not an issue. However, once specifying a default and a power-on/reset input file by its file name rather than index will be implemented, this will cause an inconsistency. It would be counter-intuitive to the user if different ways of specifying the input files would result in different outputs. Also, there is no reason why listing an input file multiple times on the command line should produce a different output than omitting it and having it used as default.

This pull request contains a series of commits which refactor `icemulti` in a way which makes this change possible. In addition, it prints the now stored image filenames along with the offsets if offset printing has been requested on the command line.