### PR TITLE
Basic support for UltraPlus 5k

### DIFF
--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -1148,7 +1148,7 @@ extra_bits_db = {
         (0, 690, 334): ("padin_glb_netwk", "0"), # (0 1)  (690 334)  (690 334)  routing T_0_0.padin_0 <X> T_0_0.glb_netwk_0
         (1, 691, 334): ("padin_glb_netwk", "1"), # (1 1)  (691 334)  (691 334)  routing T_0_0.padin_1 <X> T_0_0.glb_netwk_1
         (0, 690, 336): ("padin_glb_netwk", "2"), # (0 3)  (690 336)  (690 336)  routing T_0_0.padin_2 <X> T_0_0.glb_netwk_2
-        (1, 871, 271): ("padin_glb_netwk", "3"),
+        (1, 871, 271): ("padin_glb_netwk", "3"), # TODO: 3-6 are not correct - but  may not better
         (1, 870, 270): ("padin_glb_netwk", "4"),
         (1, 871, 270): ("padin_glb_netwk", "5"),
         (0, 870, 271): ("padin_glb_netwk", "6"),
@@ -1678,10 +1678,13 @@ padin_pio_db = {
     ],
     "5k": [
         ( 6,  0, 1),
+        (12,  0, 1),
+        (13,  0, 0),
         (19,  0, 1),
         ( 6, 31, 0),
         (12, 31, 1),
         (13, 31, 0),
+        (19, 31, 0), #This is probably wrong, but the pin seems partially broken in icecube too, and it means we have the right number of GBs to keep arachne happy
     ],
     "8k": [
         (33, 16, 1),

--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -1145,14 +1145,14 @@ extra_bits_db = {
         (0, 331, 143): ("padin_glb_netwk", "7"),
     },
     "5k": {
-        (0, 690, 334): ("padin_glb_netwk", "0"), # (0 1)  (690 334)  (690 334)  routing T_0_0.padin_0 <X> T_0_0.glb_netwk_0
-        (0, 691, 334): ("padin_glb_netwk", "1"), # (1 1)  (691 334)  (691 334)  routing T_0_0.padin_1 <X> T_0_0.glb_netwk_1
-        (1, 690, 175): ("padin_glb_netwk", "2"), # (0 3)  (690 336)  (690 336)  routing T_0_0.padin_2 <X> T_0_0.glb_netwk_2
-        (1, 871, 271): ("padin_glb_netwk", "3"), # TODO: 3-6 are not correct - but  may not better
-        (1, 870, 270): ("padin_glb_netwk", "4"),
-        (1, 871, 270): ("padin_glb_netwk", "5"),
-        (0, 870, 271): ("padin_glb_netwk", "6"),
-        (1, 691, 335): ("padin_glb_netwk", "7"), # (1 0)  (691 335)  (691 335)  routing T_0_0.padin_7 <X> T_0_0.glb_netwk_7
+        (0, 690, 334): ("padin_glb_netwk", "0"), # check
+        (0, 691, 334): ("padin_glb_netwk", "1"), # good
+        (1, 690, 175): ("padin_glb_netwk", "2"), # good
+        (1, 691, 175): ("padin_glb_netwk", "3"), # check
+        (1, 690, 174): ("padin_glb_netwk", "4"), # good (INTOSC only)
+        (1, 691, 174): ("padin_glb_netwk", "5"), # good (INTOSC only)
+        (0, 690, 335): ("padin_glb_netwk", "6"), # check
+        (0, 691, 335): ("padin_glb_netwk", "7"), # good
     },
     "8k": {
         (0, 870, 270): ("padin_glb_netwk", "0"),

--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -1190,8 +1190,8 @@ gbufin_db = {
     "5k": [
         ( 6,  0,  6), #checked
         (12,  0,  5), #checked
-        (13,  0,  7), #unknown
-        (19,  0,  0), #checked
+        (13,  0,  0), #checked
+        (19,  0,  7), #checked
         ( 6, 31,  3), #checked
         (12, 31,  4), #checked
         (13, 31,  1), #checked

--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -1146,8 +1146,8 @@ extra_bits_db = {
     },
     "5k": {
         (0, 690, 334): ("padin_glb_netwk", "0"), # (0 1)  (690 334)  (690 334)  routing T_0_0.padin_0 <X> T_0_0.glb_netwk_0
-        (1, 691, 334): ("padin_glb_netwk", "1"), # (1 1)  (691 334)  (691 334)  routing T_0_0.padin_1 <X> T_0_0.glb_netwk_1
-        (0, 690, 336): ("padin_glb_netwk", "2"), # (0 3)  (690 336)  (690 336)  routing T_0_0.padin_2 <X> T_0_0.glb_netwk_2
+        (0, 691, 334): ("padin_glb_netwk", "1"), # (1 1)  (691 334)  (691 334)  routing T_0_0.padin_1 <X> T_0_0.glb_netwk_1
+        (1, 690, 175): ("padin_glb_netwk", "2"), # (0 3)  (690 336)  (690 336)  routing T_0_0.padin_2 <X> T_0_0.glb_netwk_2
         (1, 871, 271): ("padin_glb_netwk", "3"), # TODO: 3-6 are not correct - but  may not better
         (1, 870, 270): ("padin_glb_netwk", "4"),
         (1, 871, 270): ("padin_glb_netwk", "5"),

--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -1677,14 +1677,16 @@ padin_pio_db = {
         ( 6, 17, 1),  # glb_netwk_7
     ],
     "5k": [
-        ( 6,  0, 1),
-        (12,  0, 1),
-        (13,  0, 0),
-        (19,  0, 1),
-        ( 6, 31, 0),
-        (12, 31, 1),
-        (13, 31, 0),
-        (19, 31, 0), #This is probably wrong, but the pin seems partially broken in icecube too, and it means we have the right number of GBs to keep arachne happy
+        (19,  0, 1), #0 fixed
+        ( 6,  0, 1), #1 fixed
+        (13, 31, 0), #2 fixed
+        (13,  0, 0), #3 fixed
+        
+        (19, 31, 0), #These two are questionable, but keep the order correct
+        ( 6, 31, 0), #They may need to be fixed if other package options are added.
+
+        (12,  0, 1), #6 fixed
+        (12, 31, 1), #7 fixed
     ],
     "8k": [
         (33, 16, 1),

--- a/icebox/iceboxdb.py
+++ b/icebox/iceboxdb.py
@@ -5372,19 +5372,32 @@ B2[25],B3[22],!B3[23],!B3[24],B3[25]	buffer	bnr_op_6	lc_trk_g0_6
 B6[25],B7[22],!B7[23],!B7[24],B7[25]	buffer	bnr_op_6	lc_trk_g1_6
 B2[21],B2[22],!B2[23],!B2[24],B3[21]	buffer	bnr_op_7	lc_trk_g0_7
 B6[21],B6[22],!B6[23],!B6[24],B7[21]	buffer	bnr_op_7	lc_trk_g1_7
+!B0[14],!B1[14],B1[15],!B1[16],B1[17]	buffer	bot_op_0	lc_trk_g0_0
+!B4[14],!B5[14],B5[15],!B5[16],B5[17]	buffer	bot_op_0	lc_trk_g1_0
 !B0[25],B1[22],!B1[23],B1[24],!B1[25]	buffer	bot_op_2	lc_trk_g0_2
+!B4[25],B5[22],!B5[23],B5[24],!B5[25]	buffer	bot_op_2	lc_trk_g1_2
+!B2[14],!B3[14],B3[15],!B3[16],B3[17]	buffer	bot_op_4	lc_trk_g0_4
+!B6[14],!B7[14],B7[15],!B7[16],B7[17]	buffer	bot_op_4	lc_trk_g1_4
+!B2[25],B3[22],!B3[23],B3[24],!B3[25]	buffer	bot_op_6	lc_trk_g0_6
 !B6[25],B7[22],!B7[23],B7[24],!B7[25]	buffer	bot_op_6	lc_trk_g1_6
 !B2[14],!B3[14],!B3[15],!B3[16],B3[17]	buffer	glb2local_0	lc_trk_g0_4
 !B2[15],!B2[16],B2[17],!B2[18],!B3[18]	buffer	glb2local_1	lc_trk_g0_5
 !B2[25],B3[22],!B3[23],!B3[24],!B3[25]	buffer	glb2local_2	lc_trk_g0_6
 !B2[21],B2[22],!B2[23],!B2[24],!B3[21]	buffer	glb2local_3	lc_trk_g0_7
 !B2[0],!B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_0	wire_bram/ram/RCLK
+!B6[0],B6[1],B7[0],!B7[1]	buffer	glb_netwk_1	glb2local_0
+!B8[0],B8[1],B9[0],!B9[1]	buffer	glb_netwk_1	glb2local_1
+!B10[0],B10[1],B11[0],!B11[1]	buffer	glb_netwk_1	glb2local_2
 !B12[0],B12[1],B13[0],!B13[1]	buffer	glb_netwk_1	glb2local_3
 !B2[0],!B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_1	wire_bram/ram/RCLK
 B2[0],!B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_2	wire_bram/ram/RCLK
+!B14[0],B14[1],B15[0],!B15[1]	buffer	glb_netwk_2	wire_bram/ram/RE
 B6[0],B6[1],B7[0],!B7[1]	buffer	glb_netwk_3	glb2local_0
+B8[0],B8[1],B9[0],!B9[1]	buffer	glb_netwk_3	glb2local_1
+B10[0],B10[1],B11[0],!B11[1]	buffer	glb_netwk_3	glb2local_2
 B12[0],B12[1],B13[0],!B13[1]	buffer	glb_netwk_3	glb2local_3
 B2[0],!B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_3	wire_bram/ram/RCLK
+!B6[0],B6[1],!B7[0],B7[1]	buffer	glb_netwk_4	glb2local_0
 !B8[0],B8[1],!B9[0],B9[1]	buffer	glb_netwk_4	glb2local_1
 !B10[0],B10[1],!B11[0],B11[1]	buffer	glb_netwk_4	glb2local_2
 !B12[0],B12[1],!B13[0],B13[1]	buffer	glb_netwk_4	glb2local_3
@@ -5396,11 +5409,15 @@ B14[0],B14[1],!B15[0],!B15[1]	buffer	glb_netwk_4	wire_bram/ram/RE
 !B12[0],B12[1],B13[0],B13[1]	buffer	glb_netwk_5	glb2local_3
 !B2[0],B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_5	wire_bram/ram/RCLK
 B4[0],B4[1],!B5[0],!B5[1]	buffer	glb_netwk_5	wire_bram/ram/RCLKE
+B6[0],B6[1],!B7[0],B7[1]	buffer	glb_netwk_6	glb2local_0
 B8[0],B8[1],!B9[0],B9[1]	buffer	glb_netwk_6	glb2local_1
 B10[0],B10[1],!B11[0],B11[1]	buffer	glb_netwk_6	glb2local_2
 B12[0],B12[1],!B13[0],B13[1]	buffer	glb_netwk_6	glb2local_3
 B2[0],B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_6	wire_bram/ram/RCLK
 B14[0],B14[1],B15[0],!B15[1]	buffer	glb_netwk_6	wire_bram/ram/RE
+B6[0],B6[1],B7[0],B7[1]	buffer	glb_netwk_7	glb2local_0
+B8[0],B8[1],B9[0],B9[1]	buffer	glb_netwk_7	glb2local_1
+B10[0],B10[1],B11[0],B11[1]	buffer	glb_netwk_7	glb2local_2
 B2[0],B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_7	wire_bram/ram/RCLK
 !B0[26],!B1[26],!B1[27],!B1[28],B1[29]	buffer	lc_trk_g0_0	input0_0
 !B4[26],!B5[26],!B5[27],!B5[28],B5[29]	buffer	lc_trk_g0_0	input0_2
@@ -5468,6 +5485,7 @@ B2[26],!B3[26],!B3[27],!B3[28],B3[29]	buffer	lc_trk_g0_5	input0_1
 B6[26],!B7[26],!B7[27],!B7[28],B7[29]	buffer	lc_trk_g0_5	input0_3
 B10[26],!B11[26],!B11[27],!B11[28],B11[29]	buffer	lc_trk_g0_5	input0_5
 B14[26],!B15[26],!B15[27],!B15[28],B15[29]	buffer	lc_trk_g0_5	input0_7
+B10[35],B11[32],!B11[33],!B11[34],!B11[35]	buffer	lc_trk_g0_5	input2_5
 B14[35],B15[32],!B15[33],!B15[34],!B15[35]	buffer	lc_trk_g0_5	input2_7
 B8[31],B8[32],!B8[33],!B8[34],!B9[31]	buffer	lc_trk_g0_5	wire_bram/ram/MASK_11
 B4[31],B4[32],!B4[33],!B4[34],!B5[31]	buffer	lc_trk_g0_5	wire_bram/ram/MASK_13
@@ -5494,6 +5512,7 @@ B2[26],B3[26],!B3[27],!B3[28],B3[29]	buffer	lc_trk_g0_7	input0_1
 B6[26],B7[26],!B7[27],!B7[28],B7[29]	buffer	lc_trk_g0_7	input0_3
 B10[26],B11[26],!B11[27],!B11[28],B11[29]	buffer	lc_trk_g0_7	input0_5
 B14[26],B15[26],!B15[27],!B15[28],B15[29]	buffer	lc_trk_g0_7	input0_7
+B10[35],B11[32],!B11[33],!B11[34],B11[35]	buffer	lc_trk_g0_7	input2_5
 B14[35],B15[32],!B15[33],!B15[34],B15[35]	buffer	lc_trk_g0_7	input2_7
 B8[31],B8[32],!B8[33],!B8[34],B9[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_11
 B4[31],B4[32],!B4[33],!B4[34],B5[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_13
@@ -5510,6 +5529,7 @@ B12[31],B12[32],!B12[33],!B12[34],B13[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_
 !B10[35],B11[32],!B11[33],B11[34],!B11[35]	buffer	lc_trk_g1_0	input2_5
 !B14[35],B15[32],!B15[33],B15[34],!B15[35]	buffer	lc_trk_g1_0	input2_7
 !B8[31],B8[32],!B8[33],B8[34],!B9[31]	buffer	lc_trk_g1_0	wire_bram/ram/MASK_11
+!B4[31],B4[32],!B4[33],B4[34],!B5[31]	buffer	lc_trk_g1_0	wire_bram/ram/MASK_13
 !B0[31],B0[32],!B0[33],B0[34],!B1[31]	buffer	lc_trk_g1_0	wire_bram/ram/MASK_15
 !B12[31],B12[32],!B12[33],B12[34],!B13[31]	buffer	lc_trk_g1_0	wire_bram/ram/MASK_9
 B8[27],!B8[28],B8[29],!B8[30],!B9[30]	buffer	lc_trk_g1_0	wire_bram/ram/WDATA_11
@@ -5534,7 +5554,9 @@ B14[27],!B14[28],B14[29],!B14[30],!B15[30]	buffer	lc_trk_g1_1	wire_bram/ram/WDAT
 !B6[26],B7[26],B7[27],!B7[28],B7[29]	buffer	lc_trk_g1_2	input0_3
 !B10[26],B11[26],B11[27],!B11[28],B11[29]	buffer	lc_trk_g1_2	input0_5
 !B14[26],B15[26],B15[27],!B15[28],B15[29]	buffer	lc_trk_g1_2	input0_7
+!B10[35],B11[32],!B11[33],B11[34],B11[35]	buffer	lc_trk_g1_2	input2_5
 !B14[35],B15[32],!B15[33],B15[34],B15[35]	buffer	lc_trk_g1_2	input2_7
+!B8[31],B8[32],!B8[33],B8[34],B9[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_11
 !B4[31],B4[32],!B4[33],B4[34],B5[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_13
 !B0[31],B0[32],!B0[33],B0[34],B1[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_15
 !B12[31],B12[32],!B12[33],B12[34],B13[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_9
@@ -5553,6 +5575,7 @@ B12[27],!B12[28],B12[29],!B12[30],B13[30]	buffer	lc_trk_g1_2	wire_bram/ram/WDATA
 !B14[31],B14[32],!B14[33],B14[34],B15[31]	buffer	lc_trk_g1_3	wire_bram/ram/MASK_8
 !B4[0],B4[1],B5[0],B5[1]	buffer	lc_trk_g1_3	wire_bram/ram/RCLKE
 B10[27],!B10[28],B10[29],!B10[30],B11[30]	buffer	lc_trk_g1_3	wire_bram/ram/WDATA_10
+B6[27],!B6[28],B6[29],!B6[30],B7[30]	buffer	lc_trk_g1_3	wire_bram/ram/WDATA_12
 B2[27],!B2[28],B2[29],!B2[30],B3[30]	buffer	lc_trk_g1_3	wire_bram/ram/WDATA_14
 B14[27],!B14[28],B14[29],!B14[30],B15[30]	buffer	lc_trk_g1_3	wire_bram/ram/WDATA_8
 B2[26],!B3[26],B3[27],!B3[28],B3[29]	buffer	lc_trk_g1_4	input0_1
@@ -5608,6 +5631,7 @@ B2[31],B2[32],!B2[33],B2[34],B3[31]	buffer	lc_trk_g1_7	wire_bram/ram/MASK_14
 B14[31],B14[32],!B14[33],B14[34],B15[31]	buffer	lc_trk_g1_7	wire_bram/ram/MASK_8
 B10[27],!B10[28],B10[29],B10[30],B11[30]	buffer	lc_trk_g1_7	wire_bram/ram/WDATA_10
 B6[27],!B6[28],B6[29],B6[30],B7[30]	buffer	lc_trk_g1_7	wire_bram/ram/WDATA_12
+B2[27],!B2[28],B2[29],B2[30],B3[30]	buffer	lc_trk_g1_7	wire_bram/ram/WDATA_14
 B14[27],!B14[28],B14[29],B14[30],B15[30]	buffer	lc_trk_g1_7	wire_bram/ram/WDATA_8
 !B0[26],!B1[26],!B1[27],B1[28],B1[29]	buffer	lc_trk_g2_0	input0_0
 !B4[26],!B5[26],!B5[27],B5[28],B5[29]	buffer	lc_trk_g2_0	input0_2
@@ -5655,6 +5679,7 @@ B4[0],B4[1],!B5[0],B5[1]	buffer	lc_trk_g2_2	wire_bram/ram/RCLKE
 !B6[26],B7[26],!B7[27],B7[28],B7[29]	buffer	lc_trk_g2_3	input0_3
 !B10[26],B11[26],!B11[27],B11[28],B11[29]	buffer	lc_trk_g2_3	input0_5
 !B14[26],B15[26],!B15[27],B15[28],B15[29]	buffer	lc_trk_g2_3	input0_7
+!B10[35],B11[32],B11[33],!B11[34],B11[35]	buffer	lc_trk_g2_3	input2_5
 !B14[35],B15[32],B15[33],!B15[34],B15[35]	buffer	lc_trk_g2_3	input2_7
 !B8[31],B8[32],B8[33],!B8[34],B9[31]	buffer	lc_trk_g2_3	wire_bram/ram/MASK_11
 !B4[31],B4[32],B4[33],!B4[34],B5[31]	buffer	lc_trk_g2_3	wire_bram/ram/MASK_13
@@ -5711,6 +5736,7 @@ B10[26],B11[26],!B11[27],B11[28],B11[29]	buffer	lc_trk_g2_7	input0_5
 B14[26],B15[26],!B15[27],B15[28],B15[29]	buffer	lc_trk_g2_7	input0_7
 B10[35],B11[32],B11[33],!B11[34],B11[35]	buffer	lc_trk_g2_7	input2_5
 B14[35],B15[32],B15[33],!B15[34],B15[35]	buffer	lc_trk_g2_7	input2_7
+B8[31],B8[32],B8[33],!B8[34],B9[31]	buffer	lc_trk_g2_7	wire_bram/ram/MASK_11
 B4[31],B4[32],B4[33],!B4[34],B5[31]	buffer	lc_trk_g2_7	wire_bram/ram/MASK_13
 B0[31],B0[32],B0[33],!B0[34],B1[31]	buffer	lc_trk_g2_7	wire_bram/ram/MASK_15
 B12[31],B12[32],B12[33],!B12[34],B13[31]	buffer	lc_trk_g2_7	wire_bram/ram/MASK_9
@@ -5770,6 +5796,7 @@ B12[27],B12[28],B12[29],!B12[30],B13[30]	buffer	lc_trk_g3_2	wire_bram/ram/WDATA_
 !B2[31],B2[32],B2[33],B2[34],B3[31]	buffer	lc_trk_g3_3	wire_bram/ram/MASK_14
 !B14[31],B14[32],B14[33],B14[34],B15[31]	buffer	lc_trk_g3_3	wire_bram/ram/MASK_8
 B4[0],B4[1],B5[0],B5[1]	buffer	lc_trk_g3_3	wire_bram/ram/RCLKE
+B10[27],B10[28],B10[29],!B10[30],B11[30]	buffer	lc_trk_g3_3	wire_bram/ram/WDATA_10
 B6[27],B6[28],B6[29],!B6[30],B7[30]	buffer	lc_trk_g3_3	wire_bram/ram/WDATA_12
 B2[27],B2[28],B2[29],!B2[30],B3[30]	buffer	lc_trk_g3_3	wire_bram/ram/WDATA_14
 B14[27],B14[28],B14[29],!B14[30],B15[30]	buffer	lc_trk_g3_3	wire_bram/ram/WDATA_8
@@ -5805,6 +5832,7 @@ B2[26],B3[26],B3[27],B3[28],B3[29]	buffer	lc_trk_g3_6	input0_1
 B6[26],B7[26],B7[27],B7[28],B7[29]	buffer	lc_trk_g3_6	input0_3
 B10[26],B11[26],B11[27],B11[28],B11[29]	buffer	lc_trk_g3_6	input0_5
 B14[26],B15[26],B15[27],B15[28],B15[29]	buffer	lc_trk_g3_6	input0_7
+B10[35],B11[32],B11[33],B11[34],B11[35]	buffer	lc_trk_g3_6	input2_5
 B14[35],B15[32],B15[33],B15[34],B15[35]	buffer	lc_trk_g3_6	input2_7
 B8[31],B8[32],B8[33],B8[34],B9[31]	buffer	lc_trk_g3_6	wire_bram/ram/MASK_11
 B4[31],B4[32],B4[33],B4[34],B5[31]	buffer	lc_trk_g3_6	wire_bram/ram/MASK_13
@@ -5825,6 +5853,7 @@ B2[31],B2[32],B2[33],B2[34],B3[31]	buffer	lc_trk_g3_7	wire_bram/ram/MASK_14
 B14[31],B14[32],B14[33],B14[34],B15[31]	buffer	lc_trk_g3_7	wire_bram/ram/MASK_8
 B10[27],B10[28],B10[29],B10[30],B11[30]	buffer	lc_trk_g3_7	wire_bram/ram/WDATA_10
 B6[27],B6[28],B6[29],B6[30],B7[30]	buffer	lc_trk_g3_7	wire_bram/ram/WDATA_12
+B2[27],B2[28],B2[29],B2[30],B3[30]	buffer	lc_trk_g3_7	wire_bram/ram/WDATA_14
 B14[27],B14[28],B14[29],B14[30],B15[30]	buffer	lc_trk_g3_7	wire_bram/ram/WDATA_8
 B0[14],!B1[14],B1[15],!B1[16],B1[17]	buffer	lft_op_0	lc_trk_g0_0
 B4[14],!B5[14],B5[15],!B5[16],B5[17]	buffer	lft_op_0	lc_trk_g1_0
@@ -5904,6 +5933,7 @@ B6[2]	buffer	sp12_h_r_14	sp4_h_l_6
 !B2[14],B3[14],!B3[15],B3[16],B3[17]	buffer	sp12_h_r_20	lc_trk_g0_4
 !B6[14],B7[14],!B7[15],B7[16],B7[17]	buffer	sp12_h_r_20	lc_trk_g1_4
 B12[2]	buffer	sp12_h_r_20	sp4_h_l_11
+!B2[15],B2[16],B2[17],!B2[18],B3[18]	buffer	sp12_h_r_21	lc_trk_g0_5
 !B6[15],B6[16],B6[17],!B6[18],B7[18]	buffer	sp12_h_r_21	lc_trk_g1_5
 !B2[25],B3[22],B3[23],!B3[24],B3[25]	buffer	sp12_h_r_22	lc_trk_g0_6
 !B6[25],B7[22],B7[23],!B7[24],B7[25]	buffer	sp12_h_r_22	lc_trk_g1_6
@@ -5915,6 +5945,7 @@ B6[21],B6[22],!B6[23],B6[24],B7[21]	buffer	sp12_h_r_7	lc_trk_g1_7
 !B0[14],!B1[14],!B1[15],B1[16],B1[17]	buffer	sp12_h_r_8	lc_trk_g0_0
 !B4[14],!B5[14],!B5[15],B5[16],B5[17]	buffer	sp12_h_r_8	lc_trk_g1_0
 B0[2]	buffer	sp12_h_r_8	sp4_h_r_16
+!B0[15],B0[16],B0[17],!B0[18],!B1[18]	buffer	sp12_h_r_9	lc_trk_g0_1
 !B4[15],B4[16],B4[17],!B4[18],!B5[18]	buffer	sp12_h_r_9	lc_trk_g1_1
 B8[14],B9[14],B9[15],!B9[16],B9[17]	buffer	sp12_v_b_0	lc_trk_g2_0
 B12[14],B13[14],B13[15],!B13[16],B13[17]	buffer	sp12_v_b_0	lc_trk_g3_0
@@ -5990,6 +6021,7 @@ B8[21],B8[22],B8[23],B8[24],!B9[21]	buffer	sp4_h_l_22	lc_trk_g2_3
 B12[21],B12[22],B12[23],B12[24],!B13[21]	buffer	sp4_h_l_22	lc_trk_g3_3
 B10[21],B10[22],B10[23],B10[24],!B11[21]	buffer	sp4_h_l_26	lc_trk_g2_7
 B14[21],B14[22],B14[23],B14[24],!B15[21]	buffer	sp4_h_l_26	lc_trk_g3_7
+B10[25],B11[22],B11[23],B11[24],!B11[25]	buffer	sp4_h_l_27	lc_trk_g2_6
 B14[25],B15[22],B15[23],B15[24],!B15[25]	buffer	sp4_h_l_27	lc_trk_g3_6
 B8[15],B8[16],B8[17],B8[18],B9[18]	buffer	sp4_h_l_28	lc_trk_g2_1
 B12[15],B12[16],B12[17],B12[18],B13[18]	buffer	sp4_h_l_28	lc_trk_g3_1
@@ -6029,12 +6061,14 @@ B8[15],B8[16],B8[17],!B8[18],B9[18]	buffer	sp4_h_r_25	lc_trk_g2_1
 B12[15],B12[16],B12[17],!B12[18],B13[18]	buffer	sp4_h_r_25	lc_trk_g3_1
 !B10[14],B11[14],B11[15],B11[16],B11[17]	buffer	sp4_h_r_28	lc_trk_g2_4
 !B14[14],B15[14],B15[15],B15[16],B15[17]	buffer	sp4_h_r_28	lc_trk_g3_4
+B10[15],B10[16],B10[17],!B10[18],B11[18]	buffer	sp4_h_r_29	lc_trk_g2_5
 B14[15],B14[16],B14[17],!B14[18],B15[18]	buffer	sp4_h_r_29	lc_trk_g3_5
 !B0[21],B0[22],B0[23],B0[24],B1[21]	buffer	sp4_h_r_3	lc_trk_g0_3
 !B4[21],B4[22],B4[23],B4[24],B5[21]	buffer	sp4_h_r_3	lc_trk_g1_3
 !B10[21],B10[22],B10[23],B10[24],B11[21]	buffer	sp4_h_r_31	lc_trk_g2_7
 !B14[21],B14[22],B14[23],B14[24],B15[21]	buffer	sp4_h_r_31	lc_trk_g3_7
 B8[14],!B9[14],B9[15],B9[16],B9[17]	buffer	sp4_h_r_32	lc_trk_g2_0
+B12[14],!B13[14],B13[15],B13[16],B13[17]	buffer	sp4_h_r_32	lc_trk_g3_0
 B8[15],B8[16],B8[17],B8[18],!B9[18]	buffer	sp4_h_r_33	lc_trk_g2_1
 B12[15],B12[16],B12[17],B12[18],!B13[18]	buffer	sp4_h_r_33	lc_trk_g3_1
 B8[25],B9[22],B9[23],B9[24],!B9[25]	buffer	sp4_h_r_34	lc_trk_g2_2
@@ -6067,6 +6101,7 @@ B6[15],B6[16],B6[17],!B6[18],B7[18]	buffer	sp4_h_r_5	lc_trk_g1_5
 !B6[21],B6[22],B6[23],B6[24],B7[21]	buffer	sp4_h_r_7	lc_trk_g1_7
 B0[14],!B1[14],B1[15],B1[16],B1[17]	buffer	sp4_h_r_8	lc_trk_g0_0
 B4[14],!B5[14],B5[15],B5[16],B5[17]	buffer	sp4_h_r_8	lc_trk_g1_0
+B0[15],B0[16],B0[17],B0[18],!B1[18]	buffer	sp4_h_r_9	lc_trk_g0_1
 B4[15],B4[16],B4[17],B4[18],!B5[18]	buffer	sp4_h_r_9	lc_trk_g1_1
 !B4[14],!B5[14],!B5[15],!B5[16],B5[17]	buffer	sp4_r_v_b_0	lc_trk_g1_0
 !B4[15],!B4[16],B4[17],!B4[18],!B5[18]	buffer	sp4_r_v_b_1	lc_trk_g1_1
@@ -6248,15 +6283,19 @@ B12[15],!B12[16],B12[17],!B12[18],!B13[18]	buffer	tnr_op_1	lc_trk_g3_1
 !B12[25],B13[22],!B13[23],B13[24],!B13[25]	buffer	tnr_op_2	lc_trk_g3_2
 !B8[21],B8[22],!B8[23],B8[24],!B9[21]	buffer	tnr_op_3	lc_trk_g2_3
 !B12[21],B12[22],!B12[23],B12[24],!B13[21]	buffer	tnr_op_3	lc_trk_g3_3
+!B10[14],!B11[14],B11[15],!B11[16],B11[17]	buffer	tnr_op_4	lc_trk_g2_4
 !B14[14],!B15[14],B15[15],!B15[16],B15[17]	buffer	tnr_op_4	lc_trk_g3_4
 B10[15],!B10[16],B10[17],!B10[18],!B11[18]	buffer	tnr_op_5	lc_trk_g2_5
 B14[15],!B14[16],B14[17],!B14[18],!B15[18]	buffer	tnr_op_5	lc_trk_g3_5
+!B10[25],B11[22],!B11[23],B11[24],!B11[25]	buffer	tnr_op_6	lc_trk_g2_6
 !B14[25],B15[22],!B15[23],B15[24],!B15[25]	buffer	tnr_op_6	lc_trk_g3_6
 !B10[21],B10[22],!B10[23],B10[24],!B11[21]	buffer	tnr_op_7	lc_trk_g2_7
+!B14[21],B14[22],!B14[23],B14[24],!B15[21]	buffer	tnr_op_7	lc_trk_g3_7
 B10[37]	buffer	wire_bram/ram/RDATA_10	sp12_h_l_1
 B11[38]	buffer	wire_bram/ram/RDATA_10	sp12_h_l_17
 B11[40]	buffer	wire_bram/ram/RDATA_10	sp12_v_b_10
 B11[37]	buffer	wire_bram/ram/RDATA_10	sp4_h_l_15
+B11[36]	buffer	wire_bram/ram/RDATA_10	sp4_h_r_10
 B10[36]	buffer	wire_bram/ram/RDATA_10	sp4_h_r_42
 B11[41]	buffer	wire_bram/ram/RDATA_10	sp4_r_v_b_11
 B10[40]	buffer	wire_bram/ram/RDATA_10	sp4_r_v_b_27
@@ -6268,6 +6307,7 @@ B9[38]	buffer	wire_bram/ram/RDATA_11	sp12_h_l_15
 B8[37]	buffer	wire_bram/ram/RDATA_11	sp12_h_r_0
 B9[40]	buffer	wire_bram/ram/RDATA_11	sp12_v_t_7
 B9[37]	buffer	wire_bram/ram/RDATA_11	sp4_h_r_24
+B8[36]	buffer	wire_bram/ram/RDATA_11	sp4_h_r_40
 B9[36]	buffer	wire_bram/ram/RDATA_11	sp4_h_r_8
 B8[40]	buffer	wire_bram/ram/RDATA_11	sp4_r_v_b_25
 B8[41]	buffer	wire_bram/ram/RDATA_11	sp4_r_v_b_41
@@ -6303,6 +6343,7 @@ B2[37]	buffer	wire_bram/ram/RDATA_14	sp12_h_l_9
 B3[40]	buffer	wire_bram/ram/RDATA_14	sp12_v_b_18
 B2[39]	buffer	wire_bram/ram/RDATA_14	sp12_v_t_1
 B3[37]	buffer	wire_bram/ram/RDATA_14	sp4_h_r_18
+B3[36]	buffer	wire_bram/ram/RDATA_14	sp4_h_r_2
 B2[36]	buffer	wire_bram/ram/RDATA_14	sp4_h_r_34
 B2[40]	buffer	wire_bram/ram/RDATA_14	sp4_r_v_b_19
 B3[41]	buffer	wire_bram/ram/RDATA_14	sp4_r_v_b_3
@@ -6327,7 +6368,9 @@ B15[38]	buffer	wire_bram/ram/RDATA_8	sp12_h_r_22
 B15[40]	buffer	wire_bram/ram/RDATA_8	sp12_v_b_14
 B15[37]	buffer	wire_bram/ram/RDATA_8	sp4_h_l_19
 B15[36]	buffer	wire_bram/ram/RDATA_8	sp4_h_l_3
+B14[36]	buffer	wire_bram/ram/RDATA_8	sp4_h_r_46
 B15[41]	buffer	wire_bram/ram/RDATA_8	sp4_r_v_b_15
+B14[40]	buffer	wire_bram/ram/RDATA_8	sp4_r_v_b_31
 B14[41]	buffer	wire_bram/ram/RDATA_8	sp4_r_v_b_47
 B15[39]	buffer	wire_bram/ram/RDATA_8	sp4_v_b_14
 B14[39]	buffer	wire_bram/ram/RDATA_8	sp4_v_b_46
@@ -6508,7 +6551,6 @@ B10[12],!B11[11],B11[13]	routing	sp4_h_r_5	sp4_h_l_45
 !B4[11],!B4[13],B5[12]	routing	sp4_h_r_5	sp4_v_b_5
 !B6[11],B6[13],B7[12]	routing	sp4_h_r_5	sp4_v_t_40
 B14[11],B14[13],B15[12]	routing	sp4_h_r_5	sp4_v_t_46
-!B2[12],B3[11],B3[13]	routing	sp4_h_r_6	sp4_h_l_39
 !B10[5],!B11[4],B11[6]	routing	sp4_h_r_6	sp4_h_l_43
 B14[5],B15[4],!B15[6]	routing	sp4_h_r_6	sp4_h_l_44
 B12[11],!B12[13],!B13[12]	routing	sp4_h_r_6	sp4_v_b_11
@@ -6524,7 +6566,6 @@ B3[8],B3[9],B3[10]	routing	sp4_h_r_7	sp4_v_t_36
 B11[8],B11[9],!B11[10]	routing	sp4_h_r_7	sp4_v_t_42
 B6[8],!B6[9],B6[10]	routing	sp4_h_r_8	sp4_h_l_41
 !B10[12],B11[11],!B11[13]	routing	sp4_h_r_8	sp4_h_l_45
-B14[12],!B15[11],B15[13]	routing	sp4_h_r_8	sp4_h_l_46
 !B1[8],!B1[9],B1[10]	routing	sp4_h_r_8	sp4_v_b_1
 !B8[11],!B8[13],B9[12]	routing	sp4_h_r_8	sp4_v_b_8
 B2[11],B2[13],B3[12]	routing	sp4_h_r_8	sp4_v_t_39
@@ -6760,6 +6801,11 @@ B6[21],B6[22],!B6[23],!B6[24],B7[21]	buffer	bnr_op_7	lc_trk_g1_7
 !B2[25],B3[22],!B3[23],!B3[24],!B3[25]	buffer	glb2local_2	lc_trk_g0_6
 !B2[21],B2[22],!B2[23],!B2[24],!B3[21]	buffer	glb2local_3	lc_trk_g0_7
 !B2[0],!B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_0	wire_bram/ram/WCLK
+!B6[0],B6[1],B7[0],!B7[1]	buffer	glb_netwk_1	glb2local_0
+!B8[0],B8[1],B9[0],!B9[1]	buffer	glb_netwk_1	glb2local_1
+!B10[0],B10[1],B11[0],!B11[1]	buffer	glb_netwk_1	glb2local_2
+!B12[0],B12[1],B13[0],!B13[1]	buffer	glb_netwk_1	glb2local_3
+!B2[0],!B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_1	wire_bram/ram/WCLK
 B2[0],!B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_2	wire_bram/ram/WCLK
 B6[0],B6[1],B7[0],!B7[1]	buffer	glb_netwk_3	glb2local_0
 B8[0],B8[1],B9[0],!B9[1]	buffer	glb_netwk_3	glb2local_1
@@ -6770,6 +6816,7 @@ B2[0],!B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_3	wire_bram/ram/WCLK
 !B6[0],B6[1],!B7[0],B7[1]	buffer	glb_netwk_4	glb2local_0
 !B8[0],B8[1],!B9[0],B9[1]	buffer	glb_netwk_4	glb2local_1
 !B10[0],B10[1],!B11[0],B11[1]	buffer	glb_netwk_4	glb2local_2
+!B12[0],B12[1],!B13[0],B13[1]	buffer	glb_netwk_4	glb2local_3
 !B2[0],B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_4	wire_bram/ram/WCLK
 B14[0],B14[1],!B15[0],!B15[1]	buffer	glb_netwk_4	wire_bram/ram/WE
 !B6[0],B6[1],B7[0],B7[1]	buffer	glb_netwk_5	glb2local_0
@@ -6778,7 +6825,15 @@ B14[0],B14[1],!B15[0],!B15[1]	buffer	glb_netwk_4	wire_bram/ram/WE
 !B12[0],B12[1],B13[0],B13[1]	buffer	glb_netwk_5	glb2local_3
 !B2[0],B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_5	wire_bram/ram/WCLK
 B4[0],B4[1],!B5[0],!B5[1]	buffer	glb_netwk_5	wire_bram/ram/WCLKE
+B6[0],B6[1],!B7[0],B7[1]	buffer	glb_netwk_6	glb2local_0
+B8[0],B8[1],!B9[0],B9[1]	buffer	glb_netwk_6	glb2local_1
+B10[0],B10[1],!B11[0],B11[1]	buffer	glb_netwk_6	glb2local_2
+B12[0],B12[1],!B13[0],B13[1]	buffer	glb_netwk_6	glb2local_3
+B2[0],B2[1],B2[2],!B3[0],!B3[2]	buffer	glb_netwk_6	wire_bram/ram/WCLK
 B14[0],B14[1],B15[0],!B15[1]	buffer	glb_netwk_6	wire_bram/ram/WE
+B6[0],B6[1],B7[0],B7[1]	buffer	glb_netwk_7	glb2local_0
+B10[0],B10[1],B11[0],B11[1]	buffer	glb_netwk_7	glb2local_2
+B12[0],B12[1],B13[0],B13[1]	buffer	glb_netwk_7	glb2local_3
 B2[0],B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_7	wire_bram/ram/WCLK
 !B0[26],!B1[26],!B1[27],!B1[28],B1[29]	buffer	lc_trk_g0_0	input0_0
 !B4[26],!B5[26],!B5[27],!B5[28],B5[29]	buffer	lc_trk_g0_0	input0_2
@@ -6820,6 +6875,7 @@ B2[0],B2[1],B2[2],B3[0],!B3[2]	buffer	glb_netwk_7	wire_bram/ram/WCLK
 !B14[26],B15[26],!B15[27],!B15[28],B15[29]	buffer	lc_trk_g0_3	input0_7
 !B10[35],B11[32],!B11[33],!B11[34],B11[35]	buffer	lc_trk_g0_3	input2_5
 !B14[35],B15[32],!B15[33],!B15[34],B15[35]	buffer	lc_trk_g0_3	input2_7
+!B12[31],B12[32],!B12[33],!B12[34],B13[31]	buffer	lc_trk_g0_3	wire_bram/ram/MASK_1
 !B8[31],B8[32],!B8[33],!B8[34],B9[31]	buffer	lc_trk_g0_3	wire_bram/ram/MASK_3
 !B4[31],B4[32],!B4[33],!B4[34],B5[31]	buffer	lc_trk_g0_3	wire_bram/ram/MASK_5
 !B0[31],B0[32],!B0[33],!B0[34],B1[31]	buffer	lc_trk_g0_3	wire_bram/ram/MASK_7
@@ -6835,6 +6891,7 @@ B12[35],B13[32],!B13[33],!B13[34],!B13[35]	buffer	lc_trk_g0_4	input2_6
 B14[31],B14[32],!B14[33],!B14[34],!B15[31]	buffer	lc_trk_g0_4	wire_bram/ram/MASK_0
 B10[31],B10[32],!B10[33],!B10[34],!B11[31]	buffer	lc_trk_g0_4	wire_bram/ram/MASK_2
 B6[31],B6[32],!B6[33],!B6[34],!B7[31]	buffer	lc_trk_g0_4	wire_bram/ram/MASK_4
+B2[31],B2[32],!B2[33],!B2[34],!B3[31]	buffer	lc_trk_g0_4	wire_bram/ram/MASK_6
 !B14[27],!B14[28],B14[29],B14[30],!B15[30]	buffer	lc_trk_g0_4	wire_bram/ram/WDATA_0
 !B10[27],!B10[28],B10[29],B10[30],!B11[30]	buffer	lc_trk_g0_4	wire_bram/ram/WDATA_2
 !B6[27],!B6[28],B6[29],B6[30],!B7[30]	buffer	lc_trk_g0_4	wire_bram/ram/WDATA_4
@@ -6861,6 +6918,7 @@ B12[26],B13[26],!B13[27],!B13[28],B13[29]	buffer	lc_trk_g0_6	input0_6
 B12[35],B13[32],!B13[33],!B13[34],B13[35]	buffer	lc_trk_g0_6	input2_6
 B14[31],B14[32],!B14[33],!B14[34],B15[31]	buffer	lc_trk_g0_6	wire_bram/ram/MASK_0
 B10[31],B10[32],!B10[33],!B10[34],B11[31]	buffer	lc_trk_g0_6	wire_bram/ram/MASK_2
+B6[31],B6[32],!B6[33],!B6[34],B7[31]	buffer	lc_trk_g0_6	wire_bram/ram/MASK_4
 B2[31],B2[32],!B2[33],!B2[34],B3[31]	buffer	lc_trk_g0_6	wire_bram/ram/MASK_6
 !B14[27],!B14[28],B14[29],B14[30],B15[30]	buffer	lc_trk_g0_6	wire_bram/ram/WDATA_0
 !B10[27],!B10[28],B10[29],B10[30],B11[30]	buffer	lc_trk_g0_6	wire_bram/ram/WDATA_2
@@ -6874,6 +6932,8 @@ B10[35],B11[32],!B11[33],!B11[34],B11[35]	buffer	lc_trk_g0_7	input2_5
 B14[35],B15[32],!B15[33],!B15[34],B15[35]	buffer	lc_trk_g0_7	input2_7
 B12[31],B12[32],!B12[33],!B12[34],B13[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_1
 B8[31],B8[32],!B8[33],!B8[34],B9[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_3
+B4[31],B4[32],!B4[33],!B4[34],B5[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_5
+B0[31],B0[32],!B0[33],!B0[34],B1[31]	buffer	lc_trk_g0_7	wire_bram/ram/MASK_7
 !B12[27],!B12[28],B12[29],B12[30],B13[30]	buffer	lc_trk_g0_7	wire_bram/ram/WDATA_1
 !B8[27],!B8[28],B8[29],B8[30],B9[30]	buffer	lc_trk_g0_7	wire_bram/ram/WDATA_3
 !B4[27],!B4[28],B4[29],B4[30],B5[30]	buffer	lc_trk_g0_7	wire_bram/ram/WDATA_5
@@ -6914,6 +6974,8 @@ B2[27],!B2[28],B2[29],!B2[30],!B3[30]	buffer	lc_trk_g1_1	wire_bram/ram/WDATA_6
 !B14[35],B15[32],!B15[33],B15[34],B15[35]	buffer	lc_trk_g1_2	input2_7
 !B12[31],B12[32],!B12[33],B12[34],B13[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_1
 !B8[31],B8[32],!B8[33],B8[34],B9[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_3
+!B4[31],B4[32],!B4[33],B4[34],B5[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_5
+!B0[31],B0[32],!B0[33],B0[34],B1[31]	buffer	lc_trk_g1_2	wire_bram/ram/MASK_7
 B12[27],!B12[28],B12[29],!B12[30],B13[30]	buffer	lc_trk_g1_2	wire_bram/ram/WDATA_1
 B8[27],!B8[28],B8[29],!B8[30],B9[30]	buffer	lc_trk_g1_2	wire_bram/ram/WDATA_3
 B4[27],!B4[28],B4[29],!B4[30],B5[30]	buffer	lc_trk_g1_2	wire_bram/ram/WDATA_5
@@ -6951,6 +7013,7 @@ B4[26],!B5[26],B5[27],!B5[28],B5[29]	buffer	lc_trk_g1_5	input0_2
 B8[26],!B9[26],B9[27],!B9[28],B9[29]	buffer	lc_trk_g1_5	input0_4
 B12[26],!B13[26],B13[27],!B13[28],B13[29]	buffer	lc_trk_g1_5	input0_6
 B12[35],B13[32],!B13[33],B13[34],!B13[35]	buffer	lc_trk_g1_5	input2_6
+B14[31],B14[32],!B14[33],B14[34],!B15[31]	buffer	lc_trk_g1_5	wire_bram/ram/MASK_0
 B10[31],B10[32],!B10[33],B10[34],!B11[31]	buffer	lc_trk_g1_5	wire_bram/ram/MASK_2
 B6[31],B6[32],!B6[33],B6[34],!B7[31]	buffer	lc_trk_g1_5	wire_bram/ram/MASK_4
 B2[31],B2[32],!B2[33],B2[34],!B3[31]	buffer	lc_trk_g1_5	wire_bram/ram/MASK_6
@@ -6965,6 +7028,8 @@ B10[26],B11[26],B11[27],!B11[28],B11[29]	buffer	lc_trk_g1_6	input0_5
 B14[26],B15[26],B15[27],!B15[28],B15[29]	buffer	lc_trk_g1_6	input0_7
 B10[35],B11[32],!B11[33],B11[34],B11[35]	buffer	lc_trk_g1_6	input2_5
 B14[35],B15[32],!B15[33],B15[34],B15[35]	buffer	lc_trk_g1_6	input2_7
+B12[31],B12[32],!B12[33],B12[34],B13[31]	buffer	lc_trk_g1_6	wire_bram/ram/MASK_1
+B8[31],B8[32],!B8[33],B8[34],B9[31]	buffer	lc_trk_g1_6	wire_bram/ram/MASK_3
 B4[31],B4[32],!B4[33],B4[34],B5[31]	buffer	lc_trk_g1_6	wire_bram/ram/MASK_5
 B0[31],B0[32],!B0[33],B0[34],B1[31]	buffer	lc_trk_g1_6	wire_bram/ram/MASK_7
 B12[27],!B12[28],B12[29],B12[30],B13[30]	buffer	lc_trk_g1_6	wire_bram/ram/WDATA_1
@@ -6977,6 +7042,7 @@ B8[26],B9[26],B9[27],!B9[28],B9[29]	buffer	lc_trk_g1_7	input0_4
 B12[26],B13[26],B13[27],!B13[28],B13[29]	buffer	lc_trk_g1_7	input0_6
 B12[35],B13[32],!B13[33],B13[34],B13[35]	buffer	lc_trk_g1_7	input2_6
 B14[31],B14[32],!B14[33],B14[34],B15[31]	buffer	lc_trk_g1_7	wire_bram/ram/MASK_0
+B10[31],B10[32],!B10[33],B10[34],B11[31]	buffer	lc_trk_g1_7	wire_bram/ram/MASK_2
 B6[31],B6[32],!B6[33],B6[34],B7[31]	buffer	lc_trk_g1_7	wire_bram/ram/MASK_4
 B2[31],B2[32],!B2[33],B2[34],B3[31]	buffer	lc_trk_g1_7	wire_bram/ram/MASK_6
 B14[27],!B14[28],B14[29],B14[30],B15[30]	buffer	lc_trk_g1_7	wire_bram/ram/WDATA_0
@@ -7187,6 +7253,7 @@ B14[35],B15[32],B15[33],B15[34],B15[35]	buffer	lc_trk_g3_6	input2_7
 B12[31],B12[32],B12[33],B12[34],B13[31]	buffer	lc_trk_g3_6	wire_bram/ram/MASK_1
 B8[31],B8[32],B8[33],B8[34],B9[31]	buffer	lc_trk_g3_6	wire_bram/ram/MASK_3
 B4[31],B4[32],B4[33],B4[34],B5[31]	buffer	lc_trk_g3_6	wire_bram/ram/MASK_5
+B0[31],B0[32],B0[33],B0[34],B1[31]	buffer	lc_trk_g3_6	wire_bram/ram/MASK_7
 B12[27],B12[28],B12[29],B12[30],B13[30]	buffer	lc_trk_g3_6	wire_bram/ram/WDATA_1
 B8[27],B8[28],B8[29],B8[30],B9[30]	buffer	lc_trk_g3_6	wire_bram/ram/WDATA_3
 B4[27],B4[28],B4[29],B4[30],B5[30]	buffer	lc_trk_g3_6	wire_bram/ram/WDATA_5
@@ -7220,6 +7287,7 @@ B2[25],B3[22],!B3[23],B3[24],!B3[25]	buffer	lft_op_6	lc_trk_g0_6
 B6[25],B7[22],!B7[23],B7[24],!B7[25]	buffer	lft_op_6	lc_trk_g1_6
 B2[21],B2[22],!B2[23],B2[24],!B3[21]	buffer	lft_op_7	lc_trk_g0_7
 B6[21],B6[22],!B6[23],B6[24],!B7[21]	buffer	lft_op_7	lc_trk_g1_7
+B8[14],!B9[14],B9[15],!B9[16],B9[17]	buffer	rgt_op_0	lc_trk_g2_0
 B12[14],!B13[14],B13[15],!B13[16],B13[17]	buffer	rgt_op_0	lc_trk_g3_0
 B8[15],!B8[16],B8[17],B8[18],!B9[18]	buffer	rgt_op_1	lc_trk_g2_1
 B12[15],!B12[16],B12[17],B12[18],!B13[18]	buffer	rgt_op_1	lc_trk_g3_1
@@ -7237,10 +7305,12 @@ B10[21],B10[22],!B10[23],B10[24],!B11[21]	buffer	rgt_op_7	lc_trk_g2_7
 B14[21],B14[22],!B14[23],B14[24],!B15[21]	buffer	rgt_op_7	lc_trk_g3_7
 B0[21],B0[22],!B0[23],B0[24],B1[21]	buffer	sp12_h_l_0	lc_trk_g0_3
 B4[21],B4[22],!B4[23],B4[24],B5[21]	buffer	sp12_h_l_0	lc_trk_g1_3
+!B2[21],B2[22],B2[23],!B2[24],!B3[21]	buffer	sp12_h_l_12	lc_trk_g0_7
 !B6[21],B6[22],B6[23],!B6[24],!B7[21]	buffer	sp12_h_l_12	lc_trk_g1_7
 !B2[25],B3[22],B3[23],!B3[24],!B3[25]	buffer	sp12_h_l_13	lc_trk_g0_6
 !B6[25],B7[22],B7[23],!B7[24],!B7[25]	buffer	sp12_h_l_13	lc_trk_g1_6
 B6[2]	buffer	sp12_h_l_13	sp4_h_r_19
+!B0[21],B0[22],B0[23],!B0[24],B1[21]	buffer	sp12_h_l_16	lc_trk_g0_3
 !B4[21],B4[22],B4[23],!B4[24],B5[21]	buffer	sp12_h_l_16	lc_trk_g1_3
 !B2[15],B2[16],B2[17],!B2[18],B3[18]	buffer	sp12_h_l_18	lc_trk_g0_5
 !B6[15],B6[16],B6[17],!B6[18],B7[18]	buffer	sp12_h_l_18	lc_trk_g1_5
@@ -7250,6 +7320,8 @@ B14[2]	buffer	sp12_h_l_21	sp4_h_l_10
 B2[14],B3[14],B3[15],!B3[16],B3[17]	buffer	sp12_h_l_3	lc_trk_g0_4
 B6[14],B7[14],B7[15],!B7[16],B7[17]	buffer	sp12_h_l_3	lc_trk_g1_4
 B15[19]	buffer	sp12_h_l_3	sp4_h_l_3
+B2[21],B2[22],!B2[23],B2[24],B3[21]	buffer	sp12_h_l_4	lc_trk_g0_7
+B6[21],B6[22],!B6[23],B6[24],B7[21]	buffer	sp12_h_l_4	lc_trk_g1_7
 B2[25],B3[22],!B3[23],B3[24],B3[25]	buffer	sp12_h_l_5	lc_trk_g0_6
 B6[25],B7[22],!B7[23],B7[24],B7[25]	buffer	sp12_h_l_5	lc_trk_g1_6
 B14[19]	buffer	sp12_h_l_5	sp4_h_l_2
@@ -7263,11 +7335,14 @@ B4[15],!B4[16],B4[17],B4[18],B5[18]	buffer	sp12_h_r_1	lc_trk_g1_1
 !B0[25],B1[22],B1[23],!B1[24],!B1[25]	buffer	sp12_h_r_10	lc_trk_g0_2
 !B4[25],B5[22],B5[23],!B5[24],!B5[25]	buffer	sp12_h_r_10	lc_trk_g1_2
 B3[1]	buffer	sp12_h_r_10	sp4_h_r_17
+!B0[21],B0[22],B0[23],!B0[24],!B1[21]	buffer	sp12_h_r_11	lc_trk_g0_3
+!B4[21],B4[22],B4[23],!B4[24],!B5[21]	buffer	sp12_h_r_11	lc_trk_g1_3
 !B2[14],!B3[14],!B3[15],B3[16],B3[17]	buffer	sp12_h_r_12	lc_trk_g0_4
 !B6[14],!B7[14],!B7[15],B7[16],B7[17]	buffer	sp12_h_r_12	lc_trk_g1_4
 B4[2]	buffer	sp12_h_r_12	sp4_h_l_7
 !B2[15],B2[16],B2[17],!B2[18],!B3[18]	buffer	sp12_h_r_13	lc_trk_g0_5
 !B6[15],B6[16],B6[17],!B6[18],!B7[18]	buffer	sp12_h_r_13	lc_trk_g1_5
+!B0[14],B1[14],!B1[15],B1[16],B1[17]	buffer	sp12_h_r_16	lc_trk_g0_0
 !B4[14],B5[14],!B5[15],B5[16],B5[17]	buffer	sp12_h_r_16	lc_trk_g1_0
 B8[2]	buffer	sp12_h_r_16	sp4_h_r_20
 !B0[15],B0[16],B0[17],!B0[18],B1[18]	buffer	sp12_h_r_17	lc_trk_g0_1
@@ -7278,7 +7353,10 @@ B10[2]	buffer	sp12_h_r_18	sp4_h_l_8
 B0[25],B1[22],!B1[23],B1[24],B1[25]	buffer	sp12_h_r_2	lc_trk_g0_2
 B4[25],B5[22],!B5[23],B5[24],B5[25]	buffer	sp12_h_r_2	lc_trk_g1_2
 B12[19]	buffer	sp12_h_r_2	sp4_h_r_13
+!B2[14],B3[14],!B3[15],B3[16],B3[17]	buffer	sp12_h_r_20	lc_trk_g0_4
+!B6[14],B7[14],!B7[15],B7[16],B7[17]	buffer	sp12_h_r_20	lc_trk_g1_4
 B12[2]	buffer	sp12_h_r_20	sp4_h_r_22
+!B2[21],B2[22],B2[23],!B2[24],B3[21]	buffer	sp12_h_r_23	lc_trk_g0_7
 !B6[21],B6[22],B6[23],!B6[24],B7[21]	buffer	sp12_h_r_23	lc_trk_g1_7
 B2[15],!B2[16],B2[17],B2[18],B3[18]	buffer	sp12_h_r_5	lc_trk_g0_5
 B6[15],!B6[16],B6[17],B6[18],B7[18]	buffer	sp12_h_r_5	lc_trk_g1_5
@@ -7364,6 +7442,7 @@ B12[15],B12[16],B12[17],B12[18],!B13[18]	buffer	sp4_h_l_20	lc_trk_g3_1
 B8[14],!B9[14],B9[15],B9[16],B9[17]	buffer	sp4_h_l_21	lc_trk_g2_0
 B12[14],!B13[14],B13[15],B13[16],B13[17]	buffer	sp4_h_l_21	lc_trk_g3_0
 B10[21],B10[22],B10[23],B10[24],!B11[21]	buffer	sp4_h_l_26	lc_trk_g2_7
+B14[21],B14[22],B14[23],B14[24],!B15[21]	buffer	sp4_h_l_26	lc_trk_g3_7
 B10[25],B11[22],B11[23],B11[24],!B11[25]	buffer	sp4_h_l_27	lc_trk_g2_6
 B14[25],B15[22],B15[23],B15[24],!B15[25]	buffer	sp4_h_l_27	lc_trk_g3_6
 B8[15],B8[16],B8[17],B8[18],B9[18]	buffer	sp4_h_l_28	lc_trk_g2_1
@@ -7397,6 +7476,7 @@ B4[15],B4[16],B4[17],B4[18],B5[18]	buffer	sp4_h_r_17	lc_trk_g1_1
 B0[21],B0[22],B0[23],B0[24],B1[21]	buffer	sp4_h_r_19	lc_trk_g0_3
 B4[21],B4[22],B4[23],B4[24],B5[21]	buffer	sp4_h_r_19	lc_trk_g1_3
 !B0[25],B1[22],B1[23],B1[24],B1[25]	buffer	sp4_h_r_2	lc_trk_g0_2
+!B4[25],B5[22],B5[23],B5[24],B5[25]	buffer	sp4_h_r_2	lc_trk_g1_2
 B2[14],B3[14],B3[15],B3[16],B3[17]	buffer	sp4_h_r_20	lc_trk_g0_4
 B6[14],B7[14],B7[15],B7[16],B7[17]	buffer	sp4_h_r_20	lc_trk_g1_4
 B2[25],B3[22],B3[23],B3[24],B3[25]	buffer	sp4_h_r_22	lc_trk_g0_6
@@ -7627,8 +7707,11 @@ B14[15],!B14[16],B14[17],!B14[18],!B15[18]	buffer	tnr_op_5	lc_trk_g3_5
 !B14[25],B15[22],!B15[23],B15[24],!B15[25]	buffer	tnr_op_6	lc_trk_g3_6
 !B10[21],B10[22],!B10[23],B10[24],!B11[21]	buffer	tnr_op_7	lc_trk_g2_7
 !B14[21],B14[22],!B14[23],B14[24],!B15[21]	buffer	tnr_op_7	lc_trk_g3_7
+!B0[25],B1[22],!B1[23],B1[24],B1[25]	buffer	top_op_2	lc_trk_g0_2
+!B4[25],B5[22],!B5[23],B5[24],B5[25]	buffer	top_op_2	lc_trk_g1_2
 !B2[14],B3[14],B3[15],!B3[16],B3[17]	buffer	top_op_4	lc_trk_g0_4
 !B2[25],B3[22],!B3[23],B3[24],B3[25]	buffer	top_op_6	lc_trk_g0_6
+!B6[25],B7[22],!B7[23],B7[24],B7[25]	buffer	top_op_6	lc_trk_g1_6
 B15[38]	buffer	wire_bram/ram/RDATA_0	sp12_h_l_21
 B14[37]	buffer	wire_bram/ram/RDATA_0	sp12_h_l_5
 B15[40]	buffer	wire_bram/ram/RDATA_0	sp12_v_b_14
@@ -7694,6 +7777,7 @@ B5[40]	buffer	wire_bram/ram/RDATA_5	sp12_v_t_19
 B4[39]	buffer	wire_bram/ram/RDATA_5	sp12_v_t_3
 B5[37]	buffer	wire_bram/ram/RDATA_5	sp4_h_r_20
 B4[36]	buffer	wire_bram/ram/RDATA_5	sp4_h_r_36
+B5[36]	buffer	wire_bram/ram/RDATA_5	sp4_h_r_4
 B4[40]	buffer	wire_bram/ram/RDATA_5	sp4_r_v_b_21
 B4[41]	buffer	wire_bram/ram/RDATA_5	sp4_r_v_b_37
 B5[41]	buffer	wire_bram/ram/RDATA_5	sp4_r_v_b_5
@@ -7770,7 +7854,6 @@ B12[4],B12[6],B13[5]	routing	sp4_h_l_38	sp4_v_b_9
 !B6[4],!B6[6],B7[5]	routing	sp4_h_l_38	sp4_v_t_38
 B10[11],!B10[13],!B11[12]	routing	sp4_h_l_38	sp4_v_t_45
 B12[8],!B12[9],B12[10]	routing	sp4_h_l_39	sp4_h_r_10
-!B0[12],B1[11],!B1[13]	routing	sp4_h_l_39	sp4_h_r_2
 B4[12],!B5[11],B5[13]	routing	sp4_h_l_39	sp4_h_r_5
 !B0[11],B0[13],B1[12]	routing	sp4_h_l_39	sp4_v_b_2
 B8[11],B8[13],B9[12]	routing	sp4_h_l_39	sp4_v_b_8
@@ -7805,7 +7888,6 @@ B8[4],!B8[6],B9[5]	routing	sp4_h_l_43	sp4_v_b_6
 !B10[4],!B10[6],B11[5]	routing	sp4_h_l_43	sp4_v_t_43
 B14[11],!B14[13],!B15[12]	routing	sp4_h_l_43	sp4_v_t_46
 B0[5],B1[4],!B1[6]	routing	sp4_h_l_44	sp4_h_r_0
-!B4[12],B5[11],B5[13]	routing	sp4_h_l_44	sp4_h_r_5
 !B12[5],!B13[4],B13[6]	routing	sp4_h_l_44	sp4_h_r_9
 B4[4],B4[6],B5[5]	routing	sp4_h_l_44	sp4_v_b_3
 B12[4],!B12[6],B13[5]	routing	sp4_h_l_44	sp4_v_b_9

--- a/icefuzz/cached_ramb_5k.txt
+++ b/icefuzz/cached_ramb_5k.txt
@@ -1,19 +1,32 @@
 (0 0) Negative Clock bit
+(0 10) routing glb_netwk_3 <X> glb2local_2
 (0 10) routing glb_netwk_6 <X> glb2local_2
+(0 10) routing glb_netwk_7 <X> glb2local_2
+(0 11) routing glb_netwk_1 <X> glb2local_2
+(0 11) routing glb_netwk_3 <X> glb2local_2
 (0 11) routing glb_netwk_5 <X> glb2local_2
+(0 11) routing glb_netwk_7 <X> glb2local_2
+(0 12) routing glb_netwk_3 <X> glb2local_3
 (0 12) routing glb_netwk_6 <X> glb2local_3
+(0 13) routing glb_netwk_1 <X> glb2local_3
+(0 13) routing glb_netwk_3 <X> glb2local_3
 (0 13) routing glb_netwk_5 <X> glb2local_3
+(0 14) routing glb_netwk_4 <X> wire_bram/ram/RE
 (0 14) routing glb_netwk_6 <X> wire_bram/ram/RE
 (0 14) routing lc_trk_g2_4 <X> wire_bram/ram/RE
 (0 14) routing lc_trk_g3_5 <X> wire_bram/ram/RE
+(0 15) routing glb_netwk_2 <X> wire_bram/ram/RE
 (0 15) routing glb_netwk_6 <X> wire_bram/ram/RE
 (0 15) routing lc_trk_g1_5 <X> wire_bram/ram/RE
 (0 15) routing lc_trk_g3_5 <X> wire_bram/ram/RE
 (0 2) routing glb_netwk_2 <X> wire_bram/ram/RCLK
+(0 2) routing glb_netwk_3 <X> wire_bram/ram/RCLK
 (0 2) routing glb_netwk_6 <X> wire_bram/ram/RCLK
 (0 2) routing glb_netwk_7 <X> wire_bram/ram/RCLK
 (0 2) routing lc_trk_g2_0 <X> wire_bram/ram/RCLK
 (0 2) routing lc_trk_g3_1 <X> wire_bram/ram/RCLK
+(0 3) routing glb_netwk_1 <X> wire_bram/ram/RCLK
+(0 3) routing glb_netwk_3 <X> wire_bram/ram/RCLK
 (0 3) routing glb_netwk_5 <X> wire_bram/ram/RCLK
 (0 3) routing glb_netwk_7 <X> wire_bram/ram/RCLK
 (0 3) routing lc_trk_g1_1 <X> wire_bram/ram/RCLK
@@ -24,16 +37,39 @@
 (0 5) routing lc_trk_g1_3 <X> wire_bram/ram/RCLKE
 (0 5) routing lc_trk_g3_3 <X> wire_bram/ram/RCLKE
 (0 6) routing glb_netwk_3 <X> glb2local_0
+(0 6) routing glb_netwk_6 <X> glb2local_0
+(0 6) routing glb_netwk_7 <X> glb2local_0
+(0 7) routing glb_netwk_1 <X> glb2local_0
 (0 7) routing glb_netwk_3 <X> glb2local_0
 (0 7) routing glb_netwk_5 <X> glb2local_0
+(0 7) routing glb_netwk_7 <X> glb2local_0
+(0 8) routing glb_netwk_3 <X> glb2local_1
+(0 8) routing glb_netwk_6 <X> glb2local_1
+(0 8) routing glb_netwk_7 <X> glb2local_1
+(0 9) routing glb_netwk_1 <X> glb2local_1
+(0 9) routing glb_netwk_3 <X> glb2local_1
+(0 9) routing glb_netwk_5 <X> glb2local_1
+(0 9) routing glb_netwk_7 <X> glb2local_1
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_1 glb2local_2
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_3 glb2local_2
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_4 glb2local_2
 (1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_5 glb2local_2
 (1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_6 glb2local_2
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_7 glb2local_2
+(1 11) routing glb_netwk_4 <X> glb2local_2
 (1 11) routing glb_netwk_5 <X> glb2local_2
 (1 11) routing glb_netwk_6 <X> glb2local_2
+(1 11) routing glb_netwk_7 <X> glb2local_2
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_1 glb2local_3
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_3 glb2local_3
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_4 glb2local_3
 (1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_5 glb2local_3
 (1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_6 glb2local_3
+(1 13) routing glb_netwk_4 <X> glb2local_3
 (1 13) routing glb_netwk_5 <X> glb2local_3
 (1 13) routing glb_netwk_6 <X> glb2local_3
+(1 14) Enable bit of Mux _global_links/set_rst_mux => glb_netwk_2 wire_bram/ram/RE
+(1 14) Enable bit of Mux _global_links/set_rst_mux => glb_netwk_4 wire_bram/ram/RE
 (1 14) Enable bit of Mux _global_links/set_rst_mux => glb_netwk_6 wire_bram/ram/RE
 (1 14) Enable bit of Mux _global_links/set_rst_mux => lc_trk_g0_4 wire_bram/ram/RE
 (1 14) Enable bit of Mux _global_links/set_rst_mux => lc_trk_g1_5 wire_bram/ram/RE
@@ -57,15 +93,35 @@
 (1 5) routing lc_trk_g1_3 <X> wire_bram/ram/RCLKE
 (1 5) routing lc_trk_g2_2 <X> wire_bram/ram/RCLKE
 (1 5) routing lc_trk_g3_3 <X> wire_bram/ram/RCLKE
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_1 glb2local_0
 (1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_3 glb2local_0
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_4 glb2local_0
 (1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_5 glb2local_0
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_6 glb2local_0
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_7 glb2local_0
+(1 7) routing glb_netwk_4 <X> glb2local_0
 (1 7) routing glb_netwk_5 <X> glb2local_0
+(1 7) routing glb_netwk_6 <X> glb2local_0
+(1 7) routing glb_netwk_7 <X> glb2local_0
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_1 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_3 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_4 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_5 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_6 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_7 glb2local_1
+(1 9) routing glb_netwk_4 <X> glb2local_1
+(1 9) routing glb_netwk_5 <X> glb2local_1
+(1 9) routing glb_netwk_6 <X> glb2local_1
+(1 9) routing glb_netwk_7 <X> glb2local_1
 (10 0) routing sp4_h_l_40 <X> sp4_h_r_1
+(10 0) routing sp4_h_l_47 <X> sp4_h_r_1
 (10 0) routing sp4_v_b_7 <X> sp4_h_r_1
 (10 0) routing sp4_v_t_45 <X> sp4_h_r_1
 (10 1) routing sp4_h_l_42 <X> sp4_v_b_1
+(10 1) routing sp4_h_r_8 <X> sp4_v_b_1
 (10 1) routing sp4_v_t_40 <X> sp4_v_b_1
 (10 1) routing sp4_v_t_47 <X> sp4_v_b_1
+(10 10) routing sp4_h_r_11 <X> sp4_h_l_42
 (10 10) routing sp4_h_r_4 <X> sp4_h_l_42
 (10 10) routing sp4_v_b_2 <X> sp4_h_l_42
 (10 10) routing sp4_v_t_36 <X> sp4_h_l_42
@@ -73,6 +129,8 @@
 (10 11) routing sp4_h_r_1 <X> sp4_v_t_42
 (10 11) routing sp4_v_b_11 <X> sp4_v_t_42
 (10 11) routing sp4_v_b_4 <X> sp4_v_t_42
+(10 12) routing sp4_h_l_39 <X> sp4_h_r_10
+(10 12) routing sp4_h_l_42 <X> sp4_h_r_10
 (10 12) routing sp4_v_b_4 <X> sp4_h_r_10
 (10 12) routing sp4_v_t_40 <X> sp4_h_r_10
 (10 13) routing sp4_h_l_41 <X> sp4_v_b_10
@@ -88,6 +146,7 @@
 (10 15) routing sp4_v_b_2 <X> sp4_v_t_47
 (10 15) routing sp4_v_b_7 <X> sp4_v_t_47
 (10 2) routing sp4_h_r_10 <X> sp4_h_l_36
+(10 2) routing sp4_h_r_5 <X> sp4_h_l_36
 (10 2) routing sp4_v_b_8 <X> sp4_h_l_36
 (10 2) routing sp4_v_t_42 <X> sp4_h_l_36
 (10 3) routing sp4_h_l_45 <X> sp4_v_t_36
@@ -96,16 +155,24 @@
 (10 3) routing sp4_v_b_5 <X> sp4_v_t_36
 (10 4) routing sp4_h_l_36 <X> sp4_h_r_4
 (10 4) routing sp4_h_l_45 <X> sp4_h_r_4
+(10 4) routing sp4_v_b_10 <X> sp4_h_r_4
 (10 4) routing sp4_v_t_46 <X> sp4_h_r_4
 (10 5) routing sp4_h_l_47 <X> sp4_v_b_4
 (10 5) routing sp4_h_r_11 <X> sp4_v_b_4
 (10 5) routing sp4_v_t_36 <X> sp4_v_b_4
 (10 5) routing sp4_v_t_45 <X> sp4_v_b_4
+(10 6) routing sp4_h_r_1 <X> sp4_h_l_41
+(10 6) routing sp4_h_r_8 <X> sp4_h_l_41
 (10 6) routing sp4_v_b_11 <X> sp4_h_l_41
 (10 6) routing sp4_v_t_47 <X> sp4_h_l_41
 (10 7) routing sp4_h_l_46 <X> sp4_v_t_41
+(10 7) routing sp4_h_r_10 <X> sp4_v_t_41
 (10 7) routing sp4_v_b_1 <X> sp4_v_t_41
 (10 7) routing sp4_v_b_8 <X> sp4_v_t_41
+(10 8) routing sp4_h_l_41 <X> sp4_h_r_7
+(10 8) routing sp4_h_l_46 <X> sp4_h_r_7
+(10 8) routing sp4_v_b_1 <X> sp4_h_r_7
+(10 8) routing sp4_v_t_39 <X> sp4_h_r_7
 (10 9) routing sp4_h_l_36 <X> sp4_v_b_7
 (10 9) routing sp4_h_r_2 <X> sp4_v_b_7
 (10 9) routing sp4_v_t_41 <X> sp4_v_b_7
@@ -114,11 +181,15 @@
 (11 0) routing sp4_h_r_9 <X> sp4_v_b_2
 (11 0) routing sp4_v_t_43 <X> sp4_v_b_2
 (11 0) routing sp4_v_t_46 <X> sp4_v_b_2
+(11 1) routing sp4_h_l_39 <X> sp4_h_r_2
+(11 1) routing sp4_h_l_43 <X> sp4_h_r_2
 (11 1) routing sp4_v_b_2 <X> sp4_h_r_2
+(11 1) routing sp4_v_b_8 <X> sp4_h_r_2
 (11 10) routing sp4_h_l_38 <X> sp4_v_t_45
 (11 10) routing sp4_h_r_2 <X> sp4_v_t_45
 (11 10) routing sp4_v_b_0 <X> sp4_v_t_45
 (11 10) routing sp4_v_b_5 <X> sp4_v_t_45
+(11 11) routing sp4_h_r_0 <X> sp4_h_l_45
 (11 11) routing sp4_h_r_8 <X> sp4_h_l_45
 (11 11) routing sp4_v_t_39 <X> sp4_h_l_45
 (11 11) routing sp4_v_t_45 <X> sp4_h_l_45
@@ -126,6 +197,8 @@
 (11 12) routing sp4_h_r_6 <X> sp4_v_b_11
 (11 12) routing sp4_v_t_38 <X> sp4_v_b_11
 (11 12) routing sp4_v_t_45 <X> sp4_v_b_11
+(11 13) routing sp4_h_l_38 <X> sp4_h_r_11
+(11 13) routing sp4_h_l_46 <X> sp4_h_r_11
 (11 13) routing sp4_v_b_11 <X> sp4_h_r_11
 (11 13) routing sp4_v_b_5 <X> sp4_h_r_11
 (11 14) routing sp4_h_l_43 <X> sp4_v_t_46
@@ -135,36 +208,47 @@
 (11 15) routing sp4_h_r_11 <X> sp4_h_l_46
 (11 15) routing sp4_h_r_3 <X> sp4_h_l_46
 (11 15) routing sp4_v_t_40 <X> sp4_h_l_46
+(11 15) routing sp4_v_t_46 <X> sp4_h_l_46
 (11 2) routing sp4_h_l_44 <X> sp4_v_t_39
 (11 2) routing sp4_h_r_8 <X> sp4_v_t_39
 (11 2) routing sp4_v_b_11 <X> sp4_v_t_39
 (11 2) routing sp4_v_b_6 <X> sp4_v_t_39
+(11 3) routing sp4_h_r_2 <X> sp4_h_l_39
 (11 3) routing sp4_v_t_39 <X> sp4_h_l_39
 (11 3) routing sp4_v_t_45 <X> sp4_h_l_39
 (11 4) routing sp4_h_l_46 <X> sp4_v_b_5
 (11 4) routing sp4_h_r_0 <X> sp4_v_b_5
 (11 4) routing sp4_v_t_39 <X> sp4_v_b_5
 (11 4) routing sp4_v_t_44 <X> sp4_v_b_5
+(11 5) routing sp4_h_l_40 <X> sp4_h_r_5
+(11 5) routing sp4_h_l_44 <X> sp4_h_r_5
 (11 5) routing sp4_v_b_11 <X> sp4_h_r_5
 (11 5) routing sp4_v_b_5 <X> sp4_h_r_5
 (11 6) routing sp4_h_l_37 <X> sp4_v_t_40
 (11 6) routing sp4_h_r_11 <X> sp4_v_t_40
 (11 6) routing sp4_v_b_2 <X> sp4_v_t_40
 (11 6) routing sp4_v_b_9 <X> sp4_v_t_40
+(11 7) routing sp4_h_r_5 <X> sp4_h_l_40
+(11 7) routing sp4_h_r_9 <X> sp4_h_l_40
 (11 7) routing sp4_v_t_40 <X> sp4_h_l_40
 (11 7) routing sp4_v_t_46 <X> sp4_h_l_40
 (11 8) routing sp4_h_l_39 <X> sp4_v_b_8
 (11 8) routing sp4_h_r_3 <X> sp4_v_b_8
 (11 8) routing sp4_v_t_37 <X> sp4_v_b_8
 (11 8) routing sp4_v_t_40 <X> sp4_v_b_8
+(11 9) routing sp4_h_l_37 <X> sp4_h_r_8
+(11 9) routing sp4_h_l_45 <X> sp4_h_r_8
 (11 9) routing sp4_v_b_2 <X> sp4_h_r_8
 (11 9) routing sp4_v_b_8 <X> sp4_h_r_8
+(12 0) routing sp4_h_l_46 <X> sp4_h_r_2
 (12 0) routing sp4_v_b_2 <X> sp4_h_r_2
+(12 0) routing sp4_v_b_8 <X> sp4_h_r_2
 (12 0) routing sp4_v_t_39 <X> sp4_h_r_2
 (12 1) routing sp4_h_l_39 <X> sp4_v_b_2
 (12 1) routing sp4_h_l_45 <X> sp4_v_b_2
 (12 1) routing sp4_h_r_2 <X> sp4_v_b_2
 (12 1) routing sp4_v_t_46 <X> sp4_v_b_2
+(12 10) routing sp4_h_r_5 <X> sp4_h_l_45
 (12 10) routing sp4_v_b_8 <X> sp4_h_l_45
 (12 10) routing sp4_v_t_39 <X> sp4_h_l_45
 (12 10) routing sp4_v_t_45 <X> sp4_h_l_45
@@ -172,6 +256,7 @@
 (12 11) routing sp4_h_r_2 <X> sp4_v_t_45
 (12 11) routing sp4_h_r_8 <X> sp4_v_t_45
 (12 11) routing sp4_v_b_5 <X> sp4_v_t_45
+(12 12) routing sp4_h_l_45 <X> sp4_h_r_11
 (12 12) routing sp4_v_b_11 <X> sp4_h_r_11
 (12 12) routing sp4_v_b_5 <X> sp4_h_r_11
 (12 12) routing sp4_v_t_46 <X> sp4_h_r_11
@@ -181,10 +266,12 @@
 (12 13) routing sp4_v_t_45 <X> sp4_v_b_11
 (12 14) routing sp4_v_b_11 <X> sp4_h_l_46
 (12 14) routing sp4_v_t_40 <X> sp4_h_l_46
+(12 14) routing sp4_v_t_46 <X> sp4_h_l_46
 (12 15) routing sp4_h_l_46 <X> sp4_v_t_46
 (12 15) routing sp4_h_r_11 <X> sp4_v_t_46
 (12 15) routing sp4_h_r_5 <X> sp4_v_t_46
 (12 15) routing sp4_v_b_8 <X> sp4_v_t_46
+(12 2) routing sp4_h_r_11 <X> sp4_h_l_39
 (12 2) routing sp4_v_b_2 <X> sp4_h_l_39
 (12 2) routing sp4_v_t_39 <X> sp4_h_l_39
 (12 2) routing sp4_v_t_45 <X> sp4_h_l_39
@@ -192,6 +279,7 @@
 (12 3) routing sp4_h_r_2 <X> sp4_v_t_39
 (12 3) routing sp4_h_r_8 <X> sp4_v_t_39
 (12 3) routing sp4_v_b_11 <X> sp4_v_t_39
+(12 4) routing sp4_h_l_39 <X> sp4_h_r_5
 (12 4) routing sp4_v_b_11 <X> sp4_h_r_5
 (12 4) routing sp4_v_b_5 <X> sp4_h_r_5
 (12 4) routing sp4_v_t_40 <X> sp4_h_r_5
@@ -207,26 +295,36 @@
 (12 7) routing sp4_h_r_11 <X> sp4_v_t_40
 (12 7) routing sp4_h_r_5 <X> sp4_v_t_40
 (12 7) routing sp4_v_b_2 <X> sp4_v_t_40
+(12 8) routing sp4_h_l_40 <X> sp4_h_r_8
 (12 8) routing sp4_v_b_2 <X> sp4_h_r_8
 (12 8) routing sp4_v_b_8 <X> sp4_h_r_8
+(12 8) routing sp4_v_t_45 <X> sp4_h_r_8
 (12 9) routing sp4_h_l_39 <X> sp4_v_b_8
 (12 9) routing sp4_h_l_45 <X> sp4_v_b_8
+(12 9) routing sp4_h_r_8 <X> sp4_v_b_8
 (12 9) routing sp4_v_t_40 <X> sp4_v_b_8
 (13 0) routing sp4_h_l_39 <X> sp4_v_b_2
 (13 0) routing sp4_h_l_45 <X> sp4_v_b_2
 (13 0) routing sp4_v_t_39 <X> sp4_v_b_2
 (13 0) routing sp4_v_t_43 <X> sp4_v_b_2
+(13 1) routing sp4_h_l_43 <X> sp4_h_r_2
+(13 1) routing sp4_h_l_46 <X> sp4_h_r_2
+(13 1) routing sp4_v_b_8 <X> sp4_h_r_2
 (13 1) routing sp4_v_t_44 <X> sp4_h_r_2
 (13 10) routing sp4_h_r_2 <X> sp4_v_t_45
 (13 10) routing sp4_h_r_8 <X> sp4_v_t_45
 (13 10) routing sp4_v_b_0 <X> sp4_v_t_45
 (13 10) routing sp4_v_b_8 <X> sp4_v_t_45
+(13 11) routing sp4_h_r_0 <X> sp4_h_l_45
+(13 11) routing sp4_h_r_5 <X> sp4_h_l_45
 (13 11) routing sp4_v_b_3 <X> sp4_h_l_45
 (13 11) routing sp4_v_t_39 <X> sp4_h_l_45
 (13 12) routing sp4_h_l_40 <X> sp4_v_b_11
 (13 12) routing sp4_h_l_46 <X> sp4_v_b_11
 (13 12) routing sp4_v_t_38 <X> sp4_v_b_11
 (13 12) routing sp4_v_t_46 <X> sp4_v_b_11
+(13 13) routing sp4_h_l_38 <X> sp4_h_r_11
+(13 13) routing sp4_h_l_45 <X> sp4_h_r_11
 (13 13) routing sp4_v_b_5 <X> sp4_h_r_11
 (13 13) routing sp4_v_t_43 <X> sp4_h_r_11
 (13 14) routing sp4_h_r_11 <X> sp4_v_t_46
@@ -240,12 +338,15 @@
 (13 2) routing sp4_h_r_8 <X> sp4_v_t_39
 (13 2) routing sp4_v_b_2 <X> sp4_v_t_39
 (13 2) routing sp4_v_b_6 <X> sp4_v_t_39
+(13 3) routing sp4_h_r_11 <X> sp4_h_l_39
 (13 3) routing sp4_v_b_9 <X> sp4_h_l_39
 (13 3) routing sp4_v_t_45 <X> sp4_h_l_39
 (13 4) routing sp4_h_l_40 <X> sp4_v_b_5
 (13 4) routing sp4_h_l_46 <X> sp4_v_b_5
 (13 4) routing sp4_v_t_40 <X> sp4_v_b_5
 (13 4) routing sp4_v_t_44 <X> sp4_v_b_5
+(13 5) routing sp4_h_l_39 <X> sp4_h_r_5
+(13 5) routing sp4_h_l_44 <X> sp4_h_r_5
 (13 5) routing sp4_v_b_11 <X> sp4_h_r_5
 (13 5) routing sp4_v_t_37 <X> sp4_h_r_5
 (13 6) routing sp4_h_r_11 <X> sp4_v_t_40
@@ -253,20 +354,25 @@
 (13 6) routing sp4_v_b_5 <X> sp4_v_t_40
 (13 6) routing sp4_v_b_9 <X> sp4_v_t_40
 (13 7) routing sp4_h_r_2 <X> sp4_h_l_40
+(13 7) routing sp4_h_r_9 <X> sp4_h_l_40
 (13 7) routing sp4_v_b_0 <X> sp4_h_l_40
 (13 7) routing sp4_v_t_46 <X> sp4_h_l_40
 (13 8) routing sp4_h_l_39 <X> sp4_v_b_8
 (13 8) routing sp4_h_l_45 <X> sp4_v_b_8
 (13 8) routing sp4_v_t_37 <X> sp4_v_b_8
 (13 8) routing sp4_v_t_45 <X> sp4_v_b_8
+(13 9) routing sp4_h_l_37 <X> sp4_h_r_8
+(13 9) routing sp4_h_l_40 <X> sp4_h_r_8
 (13 9) routing sp4_v_b_2 <X> sp4_h_r_8
 (13 9) routing sp4_v_t_38 <X> sp4_h_r_8
+(14 0) routing bnr_op_0 <X> lc_trk_g0_0
 (14 0) routing lft_op_0 <X> lc_trk_g0_0
 (14 0) routing sp12_h_r_0 <X> lc_trk_g0_0
 (14 0) routing sp4_h_r_16 <X> lc_trk_g0_0
 (14 0) routing sp4_h_r_8 <X> lc_trk_g0_0
 (14 0) routing sp4_v_b_0 <X> lc_trk_g0_0
 (14 0) routing sp4_v_b_8 <X> lc_trk_g0_0
+(14 1) routing bnr_op_0 <X> lc_trk_g0_0
 (14 1) routing sp12_h_l_15 <X> lc_trk_g0_0
 (14 1) routing sp12_h_r_0 <X> lc_trk_g0_0
 (14 1) routing sp4_h_r_0 <X> lc_trk_g0_0
@@ -291,12 +397,14 @@
 (14 12) routing bnl_op_0 <X> lc_trk_g3_0
 (14 12) routing rgt_op_0 <X> lc_trk_g3_0
 (14 12) routing sp12_v_b_0 <X> lc_trk_g3_0
+(14 12) routing sp4_h_r_32 <X> lc_trk_g3_0
 (14 12) routing sp4_h_r_40 <X> lc_trk_g3_0
 (14 12) routing sp4_v_b_32 <X> lc_trk_g3_0
 (14 12) routing sp4_v_t_13 <X> lc_trk_g3_0
 (14 13) routing bnl_op_0 <X> lc_trk_g3_0
 (14 13) routing sp12_v_b_0 <X> lc_trk_g3_0
 (14 13) routing sp12_v_b_16 <X> lc_trk_g3_0
+(14 13) routing sp4_h_r_24 <X> lc_trk_g3_0
 (14 13) routing sp4_h_r_40 <X> lc_trk_g3_0
 (14 13) routing sp4_r_v_b_40 <X> lc_trk_g3_0
 (14 13) routing sp4_v_b_32 <X> lc_trk_g3_0
@@ -311,6 +419,7 @@
 (14 15) routing bnl_op_4 <X> lc_trk_g3_4
 (14 15) routing sp12_v_b_20 <X> lc_trk_g3_4
 (14 15) routing sp12_v_b_4 <X> lc_trk_g3_4
+(14 15) routing sp4_h_r_28 <X> lc_trk_g3_4
 (14 15) routing sp4_h_r_44 <X> lc_trk_g3_4
 (14 15) routing sp4_r_v_b_44 <X> lc_trk_g3_4
 (14 15) routing sp4_v_t_25 <X> lc_trk_g3_4
@@ -334,6 +443,7 @@
 (14 4) routing sp12_h_r_0 <X> lc_trk_g1_0
 (14 4) routing sp4_h_r_16 <X> lc_trk_g1_0
 (14 4) routing sp4_h_r_8 <X> lc_trk_g1_0
+(14 4) routing sp4_v_b_0 <X> lc_trk_g1_0
 (14 4) routing sp4_v_b_8 <X> lc_trk_g1_0
 (14 5) routing bnr_op_0 <X> lc_trk_g1_0
 (14 5) routing sp12_h_l_15 <X> lc_trk_g1_0
@@ -353,6 +463,7 @@
 (14 7) routing sp12_h_l_3 <X> lc_trk_g1_4
 (14 7) routing sp12_h_r_20 <X> lc_trk_g1_4
 (14 7) routing sp4_h_l_9 <X> lc_trk_g1_4
+(14 7) routing sp4_h_r_4 <X> lc_trk_g1_4
 (14 7) routing sp4_r_v_b_28 <X> lc_trk_g1_4
 (14 7) routing sp4_v_b_12 <X> lc_trk_g1_4
 (14 8) routing bnl_op_0 <X> lc_trk_g2_0
@@ -374,6 +485,9 @@
 (15 0) routing sp12_h_r_1 <X> lc_trk_g0_1
 (15 0) routing sp4_h_r_1 <X> lc_trk_g0_1
 (15 0) routing sp4_h_r_17 <X> lc_trk_g0_1
+(15 0) routing sp4_h_r_9 <X> lc_trk_g0_1
+(15 0) routing sp4_v_t_4 <X> lc_trk_g0_1
+(15 1) routing bot_op_0 <X> lc_trk_g0_0
 (15 1) routing lft_op_0 <X> lc_trk_g0_0
 (15 1) routing sp12_h_r_0 <X> lc_trk_g0_0
 (15 1) routing sp4_h_r_0 <X> lc_trk_g0_0
@@ -382,6 +496,7 @@
 (15 1) routing sp4_v_b_16 <X> lc_trk_g0_0
 (15 10) routing rgt_op_5 <X> lc_trk_g2_5
 (15 10) routing sp12_v_b_5 <X> lc_trk_g2_5
+(15 10) routing sp4_h_r_29 <X> lc_trk_g2_5
 (15 10) routing sp4_h_r_37 <X> lc_trk_g2_5
 (15 10) routing sp4_h_r_45 <X> lc_trk_g2_5
 (15 10) routing sp4_v_b_45 <X> lc_trk_g2_5
@@ -394,6 +509,7 @@
 (15 11) routing sp4_h_r_44 <X> lc_trk_g2_4
 (15 11) routing sp4_v_b_44 <X> lc_trk_g2_4
 (15 11) routing tnl_op_4 <X> lc_trk_g2_4
+(15 11) routing tnr_op_4 <X> lc_trk_g2_4
 (15 12) routing rgt_op_1 <X> lc_trk_g3_1
 (15 12) routing sp12_v_b_1 <X> lc_trk_g3_1
 (15 12) routing sp4_h_l_28 <X> lc_trk_g3_1
@@ -401,8 +517,11 @@
 (15 12) routing sp4_h_r_33 <X> lc_trk_g3_1
 (15 12) routing sp4_v_b_41 <X> lc_trk_g3_1
 (15 12) routing tnl_op_1 <X> lc_trk_g3_1
+(15 12) routing tnr_op_1 <X> lc_trk_g3_1
 (15 13) routing rgt_op_0 <X> lc_trk_g3_0
 (15 13) routing sp12_v_b_0 <X> lc_trk_g3_0
+(15 13) routing sp4_h_r_24 <X> lc_trk_g3_0
+(15 13) routing sp4_h_r_32 <X> lc_trk_g3_0
 (15 13) routing sp4_h_r_40 <X> lc_trk_g3_0
 (15 13) routing sp4_v_b_40 <X> lc_trk_g3_0
 (15 13) routing tnl_op_0 <X> lc_trk_g3_0
@@ -417,6 +536,7 @@
 (15 14) routing tnr_op_5 <X> lc_trk_g3_5
 (15 15) routing rgt_op_4 <X> lc_trk_g3_4
 (15 15) routing sp12_v_b_4 <X> lc_trk_g3_4
+(15 15) routing sp4_h_r_28 <X> lc_trk_g3_4
 (15 15) routing sp4_h_r_36 <X> lc_trk_g3_4
 (15 15) routing sp4_h_r_44 <X> lc_trk_g3_4
 (15 15) routing sp4_v_b_44 <X> lc_trk_g3_4
@@ -426,7 +546,9 @@
 (15 2) routing sp12_h_l_2 <X> lc_trk_g0_5
 (15 2) routing sp4_h_r_13 <X> lc_trk_g0_5
 (15 2) routing sp4_h_r_21 <X> lc_trk_g0_5
+(15 2) routing sp4_h_r_5 <X> lc_trk_g0_5
 (15 2) routing sp4_v_t_8 <X> lc_trk_g0_5
+(15 3) routing bot_op_4 <X> lc_trk_g0_4
 (15 3) routing lft_op_4 <X> lc_trk_g0_4
 (15 3) routing sp12_h_l_3 <X> lc_trk_g0_4
 (15 3) routing sp4_h_l_1 <X> lc_trk_g0_4
@@ -439,6 +561,7 @@
 (15 4) routing sp4_h_r_17 <X> lc_trk_g1_1
 (15 4) routing sp4_h_r_9 <X> lc_trk_g1_1
 (15 4) routing sp4_v_t_4 <X> lc_trk_g1_1
+(15 5) routing bot_op_0 <X> lc_trk_g1_0
 (15 5) routing lft_op_0 <X> lc_trk_g1_0
 (15 5) routing sp12_h_r_0 <X> lc_trk_g1_0
 (15 5) routing sp4_h_r_0 <X> lc_trk_g1_0
@@ -451,17 +574,21 @@
 (15 6) routing sp4_h_r_21 <X> lc_trk_g1_5
 (15 6) routing sp4_h_r_5 <X> lc_trk_g1_5
 (15 6) routing sp4_v_t_8 <X> lc_trk_g1_5
+(15 7) routing bot_op_4 <X> lc_trk_g1_4
 (15 7) routing lft_op_4 <X> lc_trk_g1_4
 (15 7) routing sp12_h_l_3 <X> lc_trk_g1_4
 (15 7) routing sp4_h_l_1 <X> lc_trk_g1_4
 (15 7) routing sp4_h_l_9 <X> lc_trk_g1_4
+(15 7) routing sp4_h_r_4 <X> lc_trk_g1_4
 (15 7) routing sp4_v_b_20 <X> lc_trk_g1_4
 (15 8) routing rgt_op_1 <X> lc_trk_g2_1
+(15 8) routing sp12_v_b_1 <X> lc_trk_g2_1
 (15 8) routing sp4_h_l_28 <X> lc_trk_g2_1
 (15 8) routing sp4_h_r_25 <X> lc_trk_g2_1
 (15 8) routing sp4_h_r_33 <X> lc_trk_g2_1
 (15 8) routing sp4_v_b_41 <X> lc_trk_g2_1
 (15 8) routing tnl_op_1 <X> lc_trk_g2_1
+(15 8) routing tnr_op_1 <X> lc_trk_g2_1
 (15 9) routing rgt_op_0 <X> lc_trk_g2_0
 (15 9) routing sp12_v_b_0 <X> lc_trk_g2_0
 (15 9) routing sp4_h_r_24 <X> lc_trk_g2_0
@@ -469,10 +596,15 @@
 (15 9) routing sp4_h_r_40 <X> lc_trk_g2_0
 (15 9) routing sp4_v_b_40 <X> lc_trk_g2_0
 (15 9) routing tnl_op_0 <X> lc_trk_g2_0
+(15 9) routing tnr_op_0 <X> lc_trk_g2_0
+(16 0) routing sp12_h_l_14 <X> lc_trk_g0_1
+(16 0) routing sp12_h_r_9 <X> lc_trk_g0_1
 (16 0) routing sp4_h_r_1 <X> lc_trk_g0_1
 (16 0) routing sp4_h_r_17 <X> lc_trk_g0_1
+(16 0) routing sp4_h_r_9 <X> lc_trk_g0_1
 (16 0) routing sp4_v_b_1 <X> lc_trk_g0_1
 (16 0) routing sp4_v_b_9 <X> lc_trk_g0_1
+(16 0) routing sp4_v_t_4 <X> lc_trk_g0_1
 (16 1) routing sp12_h_l_15 <X> lc_trk_g0_0
 (16 1) routing sp12_h_r_8 <X> lc_trk_g0_0
 (16 1) routing sp4_h_r_0 <X> lc_trk_g0_0
@@ -481,7 +613,9 @@
 (16 1) routing sp4_v_b_0 <X> lc_trk_g0_0
 (16 1) routing sp4_v_b_16 <X> lc_trk_g0_0
 (16 1) routing sp4_v_b_8 <X> lc_trk_g0_0
+(16 10) routing sp12_v_b_13 <X> lc_trk_g2_5
 (16 10) routing sp12_v_t_18 <X> lc_trk_g2_5
+(16 10) routing sp4_h_r_29 <X> lc_trk_g2_5
 (16 10) routing sp4_h_r_37 <X> lc_trk_g2_5
 (16 10) routing sp4_h_r_45 <X> lc_trk_g2_5
 (16 10) routing sp4_v_b_29 <X> lc_trk_g2_5
@@ -505,6 +639,8 @@
 (16 12) routing sp4_v_t_20 <X> lc_trk_g3_1
 (16 13) routing sp12_v_b_16 <X> lc_trk_g3_0
 (16 13) routing sp12_v_t_7 <X> lc_trk_g3_0
+(16 13) routing sp4_h_r_24 <X> lc_trk_g3_0
+(16 13) routing sp4_h_r_32 <X> lc_trk_g3_0
 (16 13) routing sp4_h_r_40 <X> lc_trk_g3_0
 (16 13) routing sp4_v_b_32 <X> lc_trk_g3_0
 (16 13) routing sp4_v_b_40 <X> lc_trk_g3_0
@@ -519,14 +655,17 @@
 (16 14) routing sp4_v_t_24 <X> lc_trk_g3_5
 (16 15) routing sp12_v_b_20 <X> lc_trk_g3_4
 (16 15) routing sp12_v_t_11 <X> lc_trk_g3_4
+(16 15) routing sp4_h_r_28 <X> lc_trk_g3_4
 (16 15) routing sp4_h_r_36 <X> lc_trk_g3_4
 (16 15) routing sp4_h_r_44 <X> lc_trk_g3_4
 (16 15) routing sp4_v_b_28 <X> lc_trk_g3_4
 (16 15) routing sp4_v_b_44 <X> lc_trk_g3_4
 (16 15) routing sp4_v_t_25 <X> lc_trk_g3_4
 (16 2) routing sp12_h_l_10 <X> lc_trk_g0_5
+(16 2) routing sp12_h_r_21 <X> lc_trk_g0_5
 (16 2) routing sp4_h_r_13 <X> lc_trk_g0_5
 (16 2) routing sp4_h_r_21 <X> lc_trk_g0_5
+(16 2) routing sp4_h_r_5 <X> lc_trk_g0_5
 (16 2) routing sp4_v_b_13 <X> lc_trk_g0_5
 (16 2) routing sp4_v_b_5 <X> lc_trk_g0_5
 (16 2) routing sp4_v_t_8 <X> lc_trk_g0_5
@@ -547,12 +686,15 @@
 (16 4) routing sp4_v_b_9 <X> lc_trk_g1_1
 (16 4) routing sp4_v_t_4 <X> lc_trk_g1_1
 (16 5) routing sp12_h_l_15 <X> lc_trk_g1_0
+(16 5) routing sp12_h_r_8 <X> lc_trk_g1_0
 (16 5) routing sp4_h_r_0 <X> lc_trk_g1_0
 (16 5) routing sp4_h_r_16 <X> lc_trk_g1_0
 (16 5) routing sp4_h_r_8 <X> lc_trk_g1_0
+(16 5) routing sp4_v_b_0 <X> lc_trk_g1_0
 (16 5) routing sp4_v_b_16 <X> lc_trk_g1_0
 (16 5) routing sp4_v_b_8 <X> lc_trk_g1_0
 (16 6) routing sp12_h_l_10 <X> lc_trk_g1_5
+(16 6) routing sp12_h_r_21 <X> lc_trk_g1_5
 (16 6) routing sp4_h_r_13 <X> lc_trk_g1_5
 (16 6) routing sp4_h_r_21 <X> lc_trk_g1_5
 (16 6) routing sp4_h_r_5 <X> lc_trk_g1_5
@@ -563,6 +705,7 @@
 (16 7) routing sp12_h_r_20 <X> lc_trk_g1_4
 (16 7) routing sp4_h_l_1 <X> lc_trk_g1_4
 (16 7) routing sp4_h_l_9 <X> lc_trk_g1_4
+(16 7) routing sp4_h_r_4 <X> lc_trk_g1_4
 (16 7) routing sp4_v_b_12 <X> lc_trk_g1_4
 (16 7) routing sp4_v_b_20 <X> lc_trk_g1_4
 (16 7) routing sp4_v_b_4 <X> lc_trk_g1_4
@@ -584,13 +727,19 @@
 (16 9) routing sp4_v_t_13 <X> lc_trk_g2_0
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => bnr_op_1 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => lft_op_1 lc_trk_g0_1
+(17 0) Enable bit of Mux _local_links/g0_mux_1 => sp12_h_l_14 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp12_h_r_1 lc_trk_g0_1
+(17 0) Enable bit of Mux _local_links/g0_mux_1 => sp12_h_r_9 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_h_r_1 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_h_r_17 lc_trk_g0_1
+(17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_h_r_9 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_r_v_b_25 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_r_v_b_34 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_v_b_1 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_v_b_9 lc_trk_g0_1
+(17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_v_t_4 lc_trk_g0_1
+(17 1) Enable bit of Mux _local_links/g0_mux_0 => bnr_op_0 lc_trk_g0_0
+(17 1) Enable bit of Mux _local_links/g0_mux_0 => bot_op_0 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => lft_op_0 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp12_h_l_15 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp12_h_r_0 lc_trk_g0_0
@@ -605,8 +754,10 @@
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp4_v_b_8 lc_trk_g0_0
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => bnl_op_5 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => rgt_op_5 lc_trk_g2_5
+(17 10) Enable bit of Mux _local_links/g2_mux_5 => sp12_v_b_13 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp12_v_b_5 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp12_v_t_18 lc_trk_g2_5
+(17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_h_r_29 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_h_r_37 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_h_r_45 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_r_v_b_13 lc_trk_g2_5
@@ -630,6 +781,7 @@
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp4_v_b_44 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp4_v_t_25 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => tnl_op_4 lc_trk_g2_4
+(17 11) Enable bit of Mux _local_links/g2_mux_4 => tnr_op_4 lc_trk_g2_4
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => bnl_op_1 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => rgt_op_1 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp12_v_b_1 lc_trk_g3_1
@@ -644,11 +796,14 @@
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp4_v_b_41 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp4_v_t_20 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => tnl_op_1 lc_trk_g3_1
+(17 12) Enable bit of Mux _local_links/g3_mux_1 => tnr_op_1 lc_trk_g3_1
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => bnl_op_0 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => rgt_op_0 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp12_v_b_0 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp12_v_b_16 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp12_v_t_7 lc_trk_g3_0
+(17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_h_r_24 lc_trk_g3_0
+(17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_h_r_32 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_h_r_40 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_r_v_b_16 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_r_v_b_40 lc_trk_g3_0
@@ -677,6 +832,7 @@
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp12_v_b_20 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp12_v_b_4 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp12_v_t_11 lc_trk_g3_4
+(17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_h_r_28 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_h_r_36 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_h_r_44 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_r_v_b_20 lc_trk_g3_4
@@ -687,16 +843,20 @@
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => tnl_op_4 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => tnr_op_4 lc_trk_g3_4
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => bnr_op_5 lc_trk_g0_5
+(17 2) Enable bit of Mux _local_links/g0_mux_5 => glb2local_1 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => lft_op_5 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp12_h_l_10 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp12_h_l_2 lc_trk_g0_5
+(17 2) Enable bit of Mux _local_links/g0_mux_5 => sp12_h_r_21 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_h_r_13 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_h_r_21 lc_trk_g0_5
+(17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_h_r_5 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_r_v_b_29 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_v_b_13 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_v_b_5 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_v_t_8 lc_trk_g0_5
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => bnr_op_4 lc_trk_g0_4
+(17 3) Enable bit of Mux _local_links/g0_mux_4 => bot_op_4 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => glb2local_0 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => lft_op_4 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => sp12_h_l_3 lc_trk_g0_4
@@ -723,20 +883,24 @@
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp4_v_b_9 lc_trk_g1_1
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp4_v_t_4 lc_trk_g1_1
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => bnr_op_0 lc_trk_g1_0
+(17 5) Enable bit of Mux _local_links/g1_mux_0 => bot_op_0 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => lft_op_0 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp12_h_l_15 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp12_h_r_0 lc_trk_g1_0
+(17 5) Enable bit of Mux _local_links/g1_mux_0 => sp12_h_r_8 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_h_r_0 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_h_r_16 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_h_r_8 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_r_v_b_0 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_r_v_b_24 lc_trk_g1_0
+(17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_v_b_0 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_v_b_16 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_v_b_8 lc_trk_g1_0
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => bnr_op_5 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => lft_op_5 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp12_h_l_10 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp12_h_l_2 lc_trk_g1_5
+(17 6) Enable bit of Mux _local_links/g1_mux_5 => sp12_h_r_21 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_h_r_13 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_h_r_21 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_h_r_5 lc_trk_g1_5
@@ -746,12 +910,14 @@
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_v_b_5 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_v_t_8 lc_trk_g1_5
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => bnr_op_4 lc_trk_g1_4
+(17 7) Enable bit of Mux _local_links/g1_mux_4 => bot_op_4 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => lft_op_4 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp12_h_l_3 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp12_h_r_12 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp12_h_r_20 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_h_l_1 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_h_l_9 lc_trk_g1_4
+(17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_h_r_4 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_r_v_b_28 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_r_v_b_4 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_v_b_12 lc_trk_g1_4
@@ -759,6 +925,7 @@
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_v_b_4 lc_trk_g1_4
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => bnl_op_1 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => rgt_op_1 lc_trk_g2_1
+(17 8) Enable bit of Mux _local_links/g2_mux_1 => sp12_v_b_1 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp12_v_b_9 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp12_v_t_14 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp4_h_l_28 lc_trk_g2_1
@@ -770,6 +937,7 @@
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp4_v_b_41 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp4_v_t_20 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => tnl_op_1 lc_trk_g2_1
+(17 8) Enable bit of Mux _local_links/g2_mux_1 => tnr_op_1 lc_trk_g2_1
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => bnl_op_0 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => rgt_op_0 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => sp12_v_b_0 lc_trk_g2_0
@@ -784,13 +952,16 @@
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => sp4_v_b_40 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => sp4_v_t_13 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => tnl_op_0 lc_trk_g2_0
+(17 9) Enable bit of Mux _local_links/g2_mux_0 => tnr_op_0 lc_trk_g2_0
 (18 0) routing bnr_op_1 <X> lc_trk_g0_1
 (18 0) routing lft_op_1 <X> lc_trk_g0_1
 (18 0) routing sp12_h_r_1 <X> lc_trk_g0_1
 (18 0) routing sp4_h_r_17 <X> lc_trk_g0_1
+(18 0) routing sp4_h_r_9 <X> lc_trk_g0_1
 (18 0) routing sp4_v_b_1 <X> lc_trk_g0_1
 (18 0) routing sp4_v_b_9 <X> lc_trk_g0_1
 (18 1) routing bnr_op_1 <X> lc_trk_g0_1
+(18 1) routing sp12_h_l_14 <X> lc_trk_g0_1
 (18 1) routing sp12_h_r_1 <X> lc_trk_g0_1
 (18 1) routing sp4_h_r_1 <X> lc_trk_g0_1
 (18 1) routing sp4_h_r_17 <X> lc_trk_g0_1
@@ -806,6 +977,7 @@
 (18 11) routing bnl_op_5 <X> lc_trk_g2_5
 (18 11) routing sp12_v_b_5 <X> lc_trk_g2_5
 (18 11) routing sp12_v_t_18 <X> lc_trk_g2_5
+(18 11) routing sp4_h_r_29 <X> lc_trk_g2_5
 (18 11) routing sp4_h_r_45 <X> lc_trk_g2_5
 (18 11) routing sp4_r_v_b_37 <X> lc_trk_g2_5
 (18 11) routing sp4_v_t_24 <X> lc_trk_g2_5
@@ -849,7 +1021,9 @@
 (18 2) routing sp4_v_b_5 <X> lc_trk_g0_5
 (18 3) routing bnr_op_5 <X> lc_trk_g0_5
 (18 3) routing sp12_h_l_2 <X> lc_trk_g0_5
+(18 3) routing sp12_h_r_21 <X> lc_trk_g0_5
 (18 3) routing sp4_h_r_21 <X> lc_trk_g0_5
+(18 3) routing sp4_h_r_5 <X> lc_trk_g0_5
 (18 3) routing sp4_r_v_b_29 <X> lc_trk_g0_5
 (18 3) routing sp4_v_b_13 <X> lc_trk_g0_5
 (18 4) routing bnr_op_1 <X> lc_trk_g1_1
@@ -875,17 +1049,20 @@
 (18 6) routing sp4_v_b_5 <X> lc_trk_g1_5
 (18 7) routing bnr_op_5 <X> lc_trk_g1_5
 (18 7) routing sp12_h_l_2 <X> lc_trk_g1_5
+(18 7) routing sp12_h_r_21 <X> lc_trk_g1_5
 (18 7) routing sp4_h_r_21 <X> lc_trk_g1_5
 (18 7) routing sp4_h_r_5 <X> lc_trk_g1_5
 (18 7) routing sp4_r_v_b_29 <X> lc_trk_g1_5
 (18 7) routing sp4_v_b_13 <X> lc_trk_g1_5
 (18 8) routing bnl_op_1 <X> lc_trk_g2_1
 (18 8) routing rgt_op_1 <X> lc_trk_g2_1
+(18 8) routing sp12_v_b_1 <X> lc_trk_g2_1
 (18 8) routing sp4_h_l_28 <X> lc_trk_g2_1
 (18 8) routing sp4_h_r_33 <X> lc_trk_g2_1
 (18 8) routing sp4_v_b_25 <X> lc_trk_g2_1
 (18 8) routing sp4_v_t_20 <X> lc_trk_g2_1
 (18 9) routing bnl_op_1 <X> lc_trk_g2_1
+(18 9) routing sp12_v_b_1 <X> lc_trk_g2_1
 (18 9) routing sp12_v_t_14 <X> lc_trk_g2_1
 (18 9) routing sp4_h_l_28 <X> lc_trk_g2_1
 (18 9) routing sp4_h_r_25 <X> lc_trk_g2_1
@@ -909,9 +1086,13 @@
 (19 8) Enable bit of Mux _span_links/cross_mux_vert_9 => sp12_v_b_19 sp4_v_t_8
 (19 9) Enable bit of Mux _span_links/cross_mux_vert_8 => sp12_v_t_14 sp4_v_b_20
 (2 0) Enable bit of Mux _span_links/cross_mux_horz_4 => sp12_h_r_8 sp4_h_r_16
+(2 10) Enable bit of Mux _span_links/cross_mux_horz_9 => sp12_h_l_17 sp4_h_r_21
 (2 12) Enable bit of Mux _span_links/cross_mux_horz_10 => sp12_h_r_20 sp4_h_l_11
+(2 14) Enable bit of Mux _span_links/cross_mux_horz_11 => sp12_h_r_22 sp4_h_r_23
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_0 wire_bram/ram/RCLK
+(2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_1 wire_bram/ram/RCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_2 wire_bram/ram/RCLK
+(2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_3 wire_bram/ram/RCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_4 wire_bram/ram/RCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_5 wire_bram/ram/RCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_6 wire_bram/ram/RCLK
@@ -951,6 +1132,7 @@
 (21 11) routing bnl_op_7 <X> lc_trk_g2_7
 (21 11) routing sp12_v_t_20 <X> lc_trk_g2_7
 (21 11) routing sp12_v_t_4 <X> lc_trk_g2_7
+(21 11) routing sp4_h_r_31 <X> lc_trk_g2_7
 (21 11) routing sp4_h_r_47 <X> lc_trk_g2_7
 (21 11) routing sp4_r_v_b_39 <X> lc_trk_g2_7
 (21 11) routing sp4_v_t_26 <X> lc_trk_g2_7
@@ -978,6 +1160,7 @@
 (21 14) routing sp4_v_b_31 <X> lc_trk_g3_7
 (21 14) routing sp4_v_t_26 <X> lc_trk_g3_7
 (21 15) routing bnl_op_7 <X> lc_trk_g3_7
+(21 15) routing sp12_v_t_20 <X> lc_trk_g3_7
 (21 15) routing sp12_v_t_4 <X> lc_trk_g3_7
 (21 15) routing sp4_h_r_31 <X> lc_trk_g3_7
 (21 15) routing sp4_h_r_47 <X> lc_trk_g3_7
@@ -986,12 +1169,14 @@
 (21 15) routing tnl_op_7 <X> lc_trk_g3_7
 (21 2) routing bnr_op_7 <X> lc_trk_g0_7
 (21 2) routing lft_op_7 <X> lc_trk_g0_7
+(21 2) routing sp12_h_r_7 <X> lc_trk_g0_7
 (21 2) routing sp4_h_r_15 <X> lc_trk_g0_7
 (21 2) routing sp4_h_r_23 <X> lc_trk_g0_7
 (21 2) routing sp4_v_b_7 <X> lc_trk_g0_7
 (21 2) routing sp4_v_t_2 <X> lc_trk_g0_7
 (21 3) routing bnr_op_7 <X> lc_trk_g0_7
 (21 3) routing sp12_h_l_20 <X> lc_trk_g0_7
+(21 3) routing sp12_h_r_7 <X> lc_trk_g0_7
 (21 3) routing sp4_h_r_23 <X> lc_trk_g0_7
 (21 3) routing sp4_h_r_7 <X> lc_trk_g0_7
 (21 3) routing sp4_r_v_b_31 <X> lc_trk_g0_7
@@ -1010,16 +1195,19 @@
 (21 5) routing sp4_h_r_3 <X> lc_trk_g1_3
 (21 5) routing sp4_r_v_b_27 <X> lc_trk_g1_3
 (21 5) routing sp4_v_b_11 <X> lc_trk_g1_3
+(21 6) routing bnr_op_7 <X> lc_trk_g1_7
 (21 6) routing lft_op_7 <X> lc_trk_g1_7
 (21 6) routing sp12_h_r_7 <X> lc_trk_g1_7
 (21 6) routing sp4_h_r_15 <X> lc_trk_g1_7
 (21 6) routing sp4_h_r_23 <X> lc_trk_g1_7
 (21 6) routing sp4_v_b_7 <X> lc_trk_g1_7
 (21 6) routing sp4_v_t_2 <X> lc_trk_g1_7
+(21 7) routing bnr_op_7 <X> lc_trk_g1_7
 (21 7) routing sp12_h_l_20 <X> lc_trk_g1_7
 (21 7) routing sp12_h_r_7 <X> lc_trk_g1_7
 (21 7) routing sp4_h_r_23 <X> lc_trk_g1_7
 (21 7) routing sp4_h_r_7 <X> lc_trk_g1_7
+(21 7) routing sp4_r_v_b_31 <X> lc_trk_g1_7
 (21 7) routing sp4_v_t_2 <X> lc_trk_g1_7
 (21 8) routing bnl_op_3 <X> lc_trk_g2_3
 (21 8) routing rgt_op_3 <X> lc_trk_g2_3
@@ -1050,6 +1238,7 @@
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_v_b_3 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_v_t_6 lc_trk_g0_3
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => bnr_op_2 lc_trk_g0_2
+(22 1) Enable bit of Mux _local_links/g0_mux_2 => bot_op_2 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => lft_op_2 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp12_h_l_1 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp12_h_l_17 lc_trk_g0_2
@@ -1068,17 +1257,22 @@
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp12_v_t_20 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp12_v_t_4 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_h_l_26 lc_trk_g2_7
+(22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_h_r_31 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_h_r_47 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_r_v_b_15 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_r_v_b_39 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_v_b_31 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_v_t_26 lc_trk_g2_7
+(22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_v_t_34 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => tnl_op_7 lc_trk_g2_7
+(22 10) Enable bit of Mux _local_links/g2_mux_7 => tnr_op_7 lc_trk_g2_7
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => bnl_op_6 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => rgt_op_6 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp12_v_b_14 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp12_v_b_22 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp12_v_t_5 lc_trk_g2_6
+(22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_h_l_19 lc_trk_g2_6
+(22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_h_l_27 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_h_r_46 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_r_v_b_14 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_r_v_b_38 lc_trk_g2_6
@@ -1086,6 +1280,7 @@
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_v_t_19 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_v_t_27 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => tnl_op_6 lc_trk_g2_6
+(22 11) Enable bit of Mux _local_links/g2_mux_6 => tnr_op_6 lc_trk_g2_6
 (22 12) Enable bit of Mux _local_links/g3_mux_3 => bnl_op_3 lc_trk_g3_3
 (22 12) Enable bit of Mux _local_links/g3_mux_3 => rgt_op_3 lc_trk_g3_3
 (22 12) Enable bit of Mux _local_links/g3_mux_3 => sp12_v_b_19 lc_trk_g3_3
@@ -1115,9 +1310,11 @@
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => sp4_v_t_15 lc_trk_g3_2
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => sp4_v_t_31 lc_trk_g3_2
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => tnl_op_2 lc_trk_g3_2
+(22 13) Enable bit of Mux _local_links/g3_mux_2 => tnr_op_2 lc_trk_g3_2
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => bnl_op_7 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => rgt_op_7 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp12_v_t_12 lc_trk_g3_7
+(22 14) Enable bit of Mux _local_links/g3_mux_7 => sp12_v_t_20 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp12_v_t_4 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_h_l_26 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_h_r_31 lc_trk_g3_7
@@ -1128,6 +1325,7 @@
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_v_t_26 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_v_t_34 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => tnl_op_7 lc_trk_g3_7
+(22 14) Enable bit of Mux _local_links/g3_mux_7 => tnr_op_7 lc_trk_g3_7
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => bnl_op_6 lc_trk_g3_6
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => rgt_op_6 lc_trk_g3_6
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => sp12_v_b_14 lc_trk_g3_6
@@ -1139,26 +1337,35 @@
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => sp4_r_v_b_22 lc_trk_g3_6
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => sp4_r_v_b_46 lc_trk_g3_6
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => sp4_v_b_46 lc_trk_g3_6
+(22 15) Enable bit of Mux _local_links/g3_mux_6 => sp4_v_t_19 lc_trk_g3_6
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => sp4_v_t_27 lc_trk_g3_6
 (22 15) Enable bit of Mux _local_links/g3_mux_6 => tnl_op_6 lc_trk_g3_6
+(22 15) Enable bit of Mux _local_links/g3_mux_6 => tnr_op_6 lc_trk_g3_6
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => bnr_op_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => glb2local_3 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => lft_op_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp12_h_l_12 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp12_h_l_20 lc_trk_g0_7
+(22 2) Enable bit of Mux _local_links/g0_mux_7 => sp12_h_r_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_h_r_15 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_h_r_23 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_h_r_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_r_v_b_31 lc_trk_g0_7
+(22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_v_b_23 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_v_b_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_v_t_2 lc_trk_g0_7
+(22 3) Enable bit of Mux _local_links/g0_mux_6 => bnr_op_6 lc_trk_g0_6
+(22 3) Enable bit of Mux _local_links/g0_mux_6 => bot_op_6 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => glb2local_2 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => lft_op_6 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp12_h_l_5 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp12_h_r_14 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp12_h_r_22 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_h_l_11 lc_trk_g0_6
+(22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_h_l_3 lc_trk_g0_6
+(22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_h_r_6 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_r_v_b_30 lc_trk_g0_6
+(22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_v_b_14 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_v_b_6 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_v_t_11 lc_trk_g0_6
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => bnr_op_3 lc_trk_g1_3
@@ -1175,6 +1382,7 @@
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => sp4_v_b_3 lc_trk_g1_3
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => sp4_v_t_6 lc_trk_g1_3
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => bnr_op_2 lc_trk_g1_2
+(22 5) Enable bit of Mux _local_links/g1_mux_2 => bot_op_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => lft_op_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp12_h_l_1 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp12_h_l_17 lc_trk_g1_2
@@ -1184,19 +1392,24 @@
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_h_r_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_r_v_b_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_r_v_b_26 lc_trk_g1_2
+(22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_v_b_10 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_v_b_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_v_t_7 lc_trk_g1_2
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => bnr_op_7 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => lft_op_7 lc_trk_g1_7
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => sp12_h_l_12 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp12_h_l_20 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp12_h_r_7 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_h_r_15 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_h_r_23 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_h_r_7 lc_trk_g1_7
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_r_v_b_31 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_r_v_b_7 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_v_b_23 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_v_b_7 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_v_t_2 lc_trk_g1_7
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => bnr_op_6 lc_trk_g1_6
+(22 7) Enable bit of Mux _local_links/g1_mux_6 => bot_op_6 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => lft_op_6 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp12_h_l_5 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp12_h_r_14 lc_trk_g1_6
@@ -1258,11 +1471,15 @@
 (23 10) routing sp12_v_t_12 <X> lc_trk_g2_7
 (23 10) routing sp12_v_t_20 <X> lc_trk_g2_7
 (23 10) routing sp4_h_l_26 <X> lc_trk_g2_7
+(23 10) routing sp4_h_r_31 <X> lc_trk_g2_7
 (23 10) routing sp4_h_r_47 <X> lc_trk_g2_7
 (23 10) routing sp4_v_b_31 <X> lc_trk_g2_7
 (23 10) routing sp4_v_t_26 <X> lc_trk_g2_7
+(23 10) routing sp4_v_t_34 <X> lc_trk_g2_7
 (23 11) routing sp12_v_b_14 <X> lc_trk_g2_6
 (23 11) routing sp12_v_b_22 <X> lc_trk_g2_6
+(23 11) routing sp4_h_l_19 <X> lc_trk_g2_6
+(23 11) routing sp4_h_l_27 <X> lc_trk_g2_6
 (23 11) routing sp4_h_r_46 <X> lc_trk_g2_6
 (23 11) routing sp4_v_b_46 <X> lc_trk_g2_6
 (23 11) routing sp4_v_t_19 <X> lc_trk_g2_6
@@ -1284,6 +1501,7 @@
 (23 13) routing sp4_v_t_15 <X> lc_trk_g3_2
 (23 13) routing sp4_v_t_31 <X> lc_trk_g3_2
 (23 14) routing sp12_v_t_12 <X> lc_trk_g3_7
+(23 14) routing sp12_v_t_20 <X> lc_trk_g3_7
 (23 14) routing sp4_h_l_26 <X> lc_trk_g3_7
 (23 14) routing sp4_h_r_31 <X> lc_trk_g3_7
 (23 14) routing sp4_h_r_47 <X> lc_trk_g3_7
@@ -1296,17 +1514,22 @@
 (23 15) routing sp4_h_l_27 <X> lc_trk_g3_6
 (23 15) routing sp4_h_r_46 <X> lc_trk_g3_6
 (23 15) routing sp4_v_b_46 <X> lc_trk_g3_6
+(23 15) routing sp4_v_t_19 <X> lc_trk_g3_6
 (23 15) routing sp4_v_t_27 <X> lc_trk_g3_6
 (23 2) routing sp12_h_l_12 <X> lc_trk_g0_7
 (23 2) routing sp12_h_l_20 <X> lc_trk_g0_7
 (23 2) routing sp4_h_r_15 <X> lc_trk_g0_7
 (23 2) routing sp4_h_r_23 <X> lc_trk_g0_7
 (23 2) routing sp4_h_r_7 <X> lc_trk_g0_7
+(23 2) routing sp4_v_b_23 <X> lc_trk_g0_7
 (23 2) routing sp4_v_b_7 <X> lc_trk_g0_7
 (23 2) routing sp4_v_t_2 <X> lc_trk_g0_7
 (23 3) routing sp12_h_r_14 <X> lc_trk_g0_6
 (23 3) routing sp12_h_r_22 <X> lc_trk_g0_6
 (23 3) routing sp4_h_l_11 <X> lc_trk_g0_6
+(23 3) routing sp4_h_l_3 <X> lc_trk_g0_6
+(23 3) routing sp4_h_r_6 <X> lc_trk_g0_6
+(23 3) routing sp4_v_b_14 <X> lc_trk_g0_6
 (23 3) routing sp4_v_b_6 <X> lc_trk_g0_6
 (23 3) routing sp4_v_t_11 <X> lc_trk_g0_6
 (23 4) routing sp12_h_l_16 <X> lc_trk_g1_3
@@ -1322,8 +1545,10 @@
 (23 5) routing sp4_h_r_10 <X> lc_trk_g1_2
 (23 5) routing sp4_h_r_18 <X> lc_trk_g1_2
 (23 5) routing sp4_h_r_2 <X> lc_trk_g1_2
+(23 5) routing sp4_v_b_10 <X> lc_trk_g1_2
 (23 5) routing sp4_v_b_2 <X> lc_trk_g1_2
 (23 5) routing sp4_v_t_7 <X> lc_trk_g1_2
+(23 6) routing sp12_h_l_12 <X> lc_trk_g1_7
 (23 6) routing sp12_h_l_20 <X> lc_trk_g1_7
 (23 6) routing sp4_h_r_15 <X> lc_trk_g1_7
 (23 6) routing sp4_h_r_23 <X> lc_trk_g1_7
@@ -1361,6 +1586,7 @@
 (24 0) routing sp4_h_r_11 <X> lc_trk_g0_3
 (24 0) routing sp4_h_r_3 <X> lc_trk_g0_3
 (24 0) routing sp4_v_t_6 <X> lc_trk_g0_3
+(24 1) routing bot_op_2 <X> lc_trk_g0_2
 (24 1) routing lft_op_2 <X> lc_trk_g0_2
 (24 1) routing sp12_h_l_1 <X> lc_trk_g0_2
 (24 1) routing sp4_h_r_10 <X> lc_trk_g0_2
@@ -1370,13 +1596,19 @@
 (24 10) routing rgt_op_7 <X> lc_trk_g2_7
 (24 10) routing sp12_v_t_4 <X> lc_trk_g2_7
 (24 10) routing sp4_h_l_26 <X> lc_trk_g2_7
+(24 10) routing sp4_h_r_31 <X> lc_trk_g2_7
 (24 10) routing sp4_h_r_47 <X> lc_trk_g2_7
+(24 10) routing sp4_v_t_34 <X> lc_trk_g2_7
 (24 10) routing tnl_op_7 <X> lc_trk_g2_7
+(24 10) routing tnr_op_7 <X> lc_trk_g2_7
 (24 11) routing rgt_op_6 <X> lc_trk_g2_6
 (24 11) routing sp12_v_t_5 <X> lc_trk_g2_6
+(24 11) routing sp4_h_l_19 <X> lc_trk_g2_6
+(24 11) routing sp4_h_l_27 <X> lc_trk_g2_6
 (24 11) routing sp4_h_r_46 <X> lc_trk_g2_6
 (24 11) routing sp4_v_b_46 <X> lc_trk_g2_6
 (24 11) routing tnl_op_6 <X> lc_trk_g2_6
+(24 11) routing tnr_op_6 <X> lc_trk_g2_6
 (24 12) routing rgt_op_3 <X> lc_trk_g3_3
 (24 12) routing sp12_v_b_3 <X> lc_trk_g3_3
 (24 12) routing sp4_h_l_14 <X> lc_trk_g3_3
@@ -1392,6 +1624,7 @@
 (24 13) routing sp4_h_r_42 <X> lc_trk_g3_2
 (24 13) routing sp4_v_t_31 <X> lc_trk_g3_2
 (24 13) routing tnl_op_2 <X> lc_trk_g3_2
+(24 13) routing tnr_op_2 <X> lc_trk_g3_2
 (24 14) routing rgt_op_7 <X> lc_trk_g3_7
 (24 14) routing sp12_v_t_4 <X> lc_trk_g3_7
 (24 14) routing sp4_h_l_26 <X> lc_trk_g3_7
@@ -1399,6 +1632,7 @@
 (24 14) routing sp4_h_r_47 <X> lc_trk_g3_7
 (24 14) routing sp4_v_t_34 <X> lc_trk_g3_7
 (24 14) routing tnl_op_7 <X> lc_trk_g3_7
+(24 14) routing tnr_op_7 <X> lc_trk_g3_7
 (24 15) routing rgt_op_6 <X> lc_trk_g3_6
 (24 15) routing sp12_v_t_5 <X> lc_trk_g3_6
 (24 15) routing sp4_h_l_19 <X> lc_trk_g3_6
@@ -1406,13 +1640,19 @@
 (24 15) routing sp4_h_r_46 <X> lc_trk_g3_6
 (24 15) routing sp4_v_b_46 <X> lc_trk_g3_6
 (24 15) routing tnl_op_6 <X> lc_trk_g3_6
+(24 15) routing tnr_op_6 <X> lc_trk_g3_6
 (24 2) routing lft_op_7 <X> lc_trk_g0_7
+(24 2) routing sp12_h_r_7 <X> lc_trk_g0_7
 (24 2) routing sp4_h_r_15 <X> lc_trk_g0_7
 (24 2) routing sp4_h_r_23 <X> lc_trk_g0_7
 (24 2) routing sp4_h_r_7 <X> lc_trk_g0_7
+(24 2) routing sp4_v_b_23 <X> lc_trk_g0_7
+(24 3) routing bot_op_6 <X> lc_trk_g0_6
 (24 3) routing lft_op_6 <X> lc_trk_g0_6
 (24 3) routing sp12_h_l_5 <X> lc_trk_g0_6
 (24 3) routing sp4_h_l_11 <X> lc_trk_g0_6
+(24 3) routing sp4_h_l_3 <X> lc_trk_g0_6
+(24 3) routing sp4_h_r_6 <X> lc_trk_g0_6
 (24 3) routing sp4_v_t_11 <X> lc_trk_g0_6
 (24 4) routing lft_op_3 <X> lc_trk_g1_3
 (24 4) routing sp12_h_r_3 <X> lc_trk_g1_3
@@ -1420,6 +1660,7 @@
 (24 4) routing sp4_h_r_11 <X> lc_trk_g1_3
 (24 4) routing sp4_h_r_3 <X> lc_trk_g1_3
 (24 4) routing sp4_v_t_6 <X> lc_trk_g1_3
+(24 5) routing bot_op_2 <X> lc_trk_g1_2
 (24 5) routing lft_op_2 <X> lc_trk_g1_2
 (24 5) routing sp12_h_l_1 <X> lc_trk_g1_2
 (24 5) routing sp4_h_r_10 <X> lc_trk_g1_2
@@ -1432,6 +1673,7 @@
 (24 6) routing sp4_h_r_23 <X> lc_trk_g1_7
 (24 6) routing sp4_h_r_7 <X> lc_trk_g1_7
 (24 6) routing sp4_v_b_23 <X> lc_trk_g1_7
+(24 7) routing bot_op_6 <X> lc_trk_g1_6
 (24 7) routing lft_op_6 <X> lc_trk_g1_6
 (24 7) routing sp12_h_l_5 <X> lc_trk_g1_6
 (24 7) routing sp4_h_l_11 <X> lc_trk_g1_6
@@ -1471,12 +1713,14 @@
 (25 10) routing bnl_op_6 <X> lc_trk_g2_6
 (25 10) routing rgt_op_6 <X> lc_trk_g2_6
 (25 10) routing sp12_v_t_5 <X> lc_trk_g2_6
+(25 10) routing sp4_h_l_27 <X> lc_trk_g2_6
 (25 10) routing sp4_h_r_46 <X> lc_trk_g2_6
 (25 10) routing sp4_v_t_19 <X> lc_trk_g2_6
 (25 10) routing sp4_v_t_27 <X> lc_trk_g2_6
 (25 11) routing bnl_op_6 <X> lc_trk_g2_6
 (25 11) routing sp12_v_b_22 <X> lc_trk_g2_6
 (25 11) routing sp12_v_t_5 <X> lc_trk_g2_6
+(25 11) routing sp4_h_l_19 <X> lc_trk_g2_6
 (25 11) routing sp4_h_r_46 <X> lc_trk_g2_6
 (25 11) routing sp4_r_v_b_38 <X> lc_trk_g2_6
 (25 11) routing sp4_v_t_27 <X> lc_trk_g2_6
@@ -1501,6 +1745,7 @@
 (25 14) routing sp12_v_t_5 <X> lc_trk_g3_6
 (25 14) routing sp4_h_l_27 <X> lc_trk_g3_6
 (25 14) routing sp4_h_r_46 <X> lc_trk_g3_6
+(25 14) routing sp4_v_t_19 <X> lc_trk_g3_6
 (25 14) routing sp4_v_t_27 <X> lc_trk_g3_6
 (25 15) routing bnl_op_6 <X> lc_trk_g3_6
 (25 15) routing sp12_v_b_22 <X> lc_trk_g3_6
@@ -1510,19 +1755,26 @@
 (25 15) routing sp4_r_v_b_46 <X> lc_trk_g3_6
 (25 15) routing sp4_v_t_27 <X> lc_trk_g3_6
 (25 15) routing tnl_op_6 <X> lc_trk_g3_6
+(25 2) routing bnr_op_6 <X> lc_trk_g0_6
 (25 2) routing lft_op_6 <X> lc_trk_g0_6
 (25 2) routing sp12_h_l_5 <X> lc_trk_g0_6
 (25 2) routing sp4_h_l_11 <X> lc_trk_g0_6
+(25 2) routing sp4_h_l_3 <X> lc_trk_g0_6
+(25 2) routing sp4_v_b_14 <X> lc_trk_g0_6
 (25 2) routing sp4_v_b_6 <X> lc_trk_g0_6
+(25 3) routing bnr_op_6 <X> lc_trk_g0_6
 (25 3) routing sp12_h_l_5 <X> lc_trk_g0_6
 (25 3) routing sp12_h_r_22 <X> lc_trk_g0_6
 (25 3) routing sp4_h_l_11 <X> lc_trk_g0_6
+(25 3) routing sp4_h_r_6 <X> lc_trk_g0_6
 (25 3) routing sp4_r_v_b_30 <X> lc_trk_g0_6
+(25 3) routing sp4_v_b_14 <X> lc_trk_g0_6
 (25 4) routing bnr_op_2 <X> lc_trk_g1_2
 (25 4) routing lft_op_2 <X> lc_trk_g1_2
 (25 4) routing sp12_h_l_1 <X> lc_trk_g1_2
 (25 4) routing sp4_h_r_10 <X> lc_trk_g1_2
 (25 4) routing sp4_h_r_18 <X> lc_trk_g1_2
+(25 4) routing sp4_v_b_10 <X> lc_trk_g1_2
 (25 4) routing sp4_v_b_2 <X> lc_trk_g1_2
 (25 5) routing bnr_op_2 <X> lc_trk_g1_2
 (25 5) routing sp12_h_l_1 <X> lc_trk_g1_2
@@ -1530,6 +1782,7 @@
 (25 5) routing sp4_h_r_18 <X> lc_trk_g1_2
 (25 5) routing sp4_h_r_2 <X> lc_trk_g1_2
 (25 5) routing sp4_r_v_b_26 <X> lc_trk_g1_2
+(25 5) routing sp4_v_b_10 <X> lc_trk_g1_2
 (25 6) routing bnr_op_6 <X> lc_trk_g1_6
 (25 6) routing lft_op_6 <X> lc_trk_g1_6
 (25 6) routing sp12_h_l_5 <X> lc_trk_g1_6
@@ -1607,6 +1860,7 @@
 (26 13) routing lc_trk_g2_6 <X> input0_6
 (26 13) routing lc_trk_g3_3 <X> input0_6
 (26 13) routing lc_trk_g3_7 <X> input0_6
+(26 14) routing lc_trk_g0_5 <X> input0_7
 (26 14) routing lc_trk_g0_7 <X> input0_7
 (26 14) routing lc_trk_g1_4 <X> input0_7
 (26 14) routing lc_trk_g1_6 <X> input0_7
@@ -1687,9 +1941,12 @@
 (26 9) routing lc_trk_g3_3 <X> input0_4
 (26 9) routing lc_trk_g3_7 <X> input0_4
 (27 0) routing lc_trk_g1_0 <X> wire_bram/ram/WDATA_15
+(27 0) routing lc_trk_g1_2 <X> wire_bram/ram/WDATA_15
 (27 0) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_15
+(27 0) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_15
 (27 0) routing lc_trk_g3_0 <X> wire_bram/ram/WDATA_15
 (27 0) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_15
+(27 0) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_15
 (27 0) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_15
 (27 1) routing lc_trk_g1_1 <X> input0_0
 (27 1) routing lc_trk_g1_3 <X> input0_0
@@ -1701,8 +1958,12 @@
 (27 1) routing lc_trk_g3_7 <X> input0_0
 (27 10) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_10
 (27 10) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_10
+(27 10) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_10
 (27 10) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_10
+(27 10) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_10
+(27 10) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_10
 (27 10) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_10
+(27 10) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_10
 (27 11) routing lc_trk_g1_0 <X> input0_5
 (27 11) routing lc_trk_g1_2 <X> input0_5
 (27 11) routing lc_trk_g1_4 <X> input0_5
@@ -1730,6 +1991,11 @@
 (27 14) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_8
 (27 14) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_8
 (27 14) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_8
+(27 14) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_8
+(27 14) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_8
+(27 14) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_8
+(27 14) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_8
+(27 14) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_8
 (27 15) routing lc_trk_g1_0 <X> input0_7
 (27 15) routing lc_trk_g1_2 <X> input0_7
 (27 15) routing lc_trk_g1_4 <X> input0_7
@@ -1740,6 +2006,12 @@
 (27 15) routing lc_trk_g3_6 <X> input0_7
 (27 2) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_14
 (27 2) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_14
+(27 2) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_14
+(27 2) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_14
+(27 2) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_14
+(27 2) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_14
+(27 2) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_14
+(27 2) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_14
 (27 3) routing lc_trk_g1_0 <X> input0_1
 (27 3) routing lc_trk_g1_2 <X> input0_1
 (27 3) routing lc_trk_g1_4 <X> input0_1
@@ -1765,7 +2037,12 @@
 (27 5) routing lc_trk_g3_5 <X> input0_2
 (27 5) routing lc_trk_g3_7 <X> input0_2
 (27 6) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_12
+(27 6) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_12
+(27 6) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_12
 (27 6) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_12
+(27 6) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_12
+(27 6) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_12
+(27 6) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_12
 (27 6) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_12
 (27 7) routing lc_trk_g1_0 <X> input0_3
 (27 7) routing lc_trk_g1_2 <X> input0_3
@@ -1775,7 +2052,11 @@
 (27 7) routing lc_trk_g3_2 <X> input0_3
 (27 7) routing lc_trk_g3_4 <X> input0_3
 (27 7) routing lc_trk_g3_6 <X> input0_3
+(27 8) routing lc_trk_g1_0 <X> wire_bram/ram/WDATA_11
 (27 8) routing lc_trk_g1_2 <X> wire_bram/ram/WDATA_11
+(27 8) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_11
+(27 8) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_11
+(27 8) routing lc_trk_g3_0 <X> wire_bram/ram/WDATA_11
 (27 8) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_11
 (27 8) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_11
 (27 8) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_11
@@ -1787,10 +2068,13 @@
 (27 9) routing lc_trk_g3_3 <X> input0_4
 (27 9) routing lc_trk_g3_5 <X> input0_4
 (27 9) routing lc_trk_g3_7 <X> input0_4
+(28 0) routing lc_trk_g2_1 <X> wire_bram/ram/WDATA_15
 (28 0) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_15
 (28 0) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_15
+(28 0) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_15
 (28 0) routing lc_trk_g3_0 <X> wire_bram/ram/WDATA_15
 (28 0) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_15
+(28 0) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_15
 (28 0) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_15
 (28 1) routing lc_trk_g2_0 <X> input0_0
 (28 1) routing lc_trk_g2_2 <X> input0_0
@@ -1800,10 +2084,14 @@
 (28 1) routing lc_trk_g3_3 <X> input0_0
 (28 1) routing lc_trk_g3_5 <X> input0_0
 (28 1) routing lc_trk_g3_7 <X> input0_0
+(28 10) routing lc_trk_g2_0 <X> wire_bram/ram/WDATA_10
 (28 10) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_10
 (28 10) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_10
 (28 10) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_10
+(28 10) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_10
+(28 10) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_10
 (28 10) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_10
+(28 10) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_10
 (28 11) routing lc_trk_g2_1 <X> input0_5
 (28 11) routing lc_trk_g2_3 <X> input0_5
 (28 11) routing lc_trk_g2_5 <X> input0_5
@@ -1828,8 +2116,14 @@
 (28 13) routing lc_trk_g3_3 <X> input0_6
 (28 13) routing lc_trk_g3_5 <X> input0_6
 (28 13) routing lc_trk_g3_7 <X> input0_6
+(28 14) routing lc_trk_g2_0 <X> wire_bram/ram/WDATA_8
 (28 14) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_8
 (28 14) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_8
+(28 14) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_8
+(28 14) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_8
+(28 14) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_8
+(28 14) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_8
+(28 14) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_8
 (28 15) routing lc_trk_g2_1 <X> input0_7
 (28 15) routing lc_trk_g2_3 <X> input0_7
 (28 15) routing lc_trk_g2_5 <X> input0_7
@@ -1840,7 +2134,12 @@
 (28 15) routing lc_trk_g3_6 <X> input0_7
 (28 2) routing lc_trk_g2_0 <X> wire_bram/ram/WDATA_14
 (28 2) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_14
+(28 2) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_14
 (28 2) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_14
+(28 2) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_14
+(28 2) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_14
+(28 2) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_14
+(28 2) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_14
 (28 3) routing lc_trk_g2_1 <X> input0_1
 (28 3) routing lc_trk_g2_3 <X> input0_1
 (28 3) routing lc_trk_g2_5 <X> input0_1
@@ -1868,6 +2167,10 @@
 (28 6) routing lc_trk_g2_0 <X> wire_bram/ram/WDATA_12
 (28 6) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_12
 (28 6) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_12
+(28 6) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_12
+(28 6) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_12
+(28 6) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_12
+(28 6) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_12
 (28 6) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_12
 (28 7) routing lc_trk_g2_1 <X> input0_3
 (28 7) routing lc_trk_g2_3 <X> input0_3
@@ -1877,8 +2180,11 @@
 (28 7) routing lc_trk_g3_2 <X> input0_3
 (28 7) routing lc_trk_g3_4 <X> input0_3
 (28 7) routing lc_trk_g3_6 <X> input0_3
+(28 8) routing lc_trk_g2_1 <X> wire_bram/ram/WDATA_11
 (28 8) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_11
+(28 8) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_11
 (28 8) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_11
+(28 8) routing lc_trk_g3_0 <X> wire_bram/ram/WDATA_11
 (28 8) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_11
 (28 8) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_11
 (28 8) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_11
@@ -1890,14 +2196,21 @@
 (28 9) routing lc_trk_g3_3 <X> input0_4
 (28 9) routing lc_trk_g3_5 <X> input0_4
 (28 9) routing lc_trk_g3_7 <X> input0_4
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_1 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_3 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_5 wire_bram/ram/WDATA_15
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_7 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_0 wire_bram/ram/WDATA_15
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_2 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_4 wire_bram/ram/WDATA_15
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_6 wire_bram/ram/WDATA_15
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_1 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_3 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_5 wire_bram/ram/WDATA_15
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_7 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_0 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_2 wire_bram/ram/WDATA_15
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_4 wire_bram/ram/WDATA_15
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_6 wire_bram/ram/WDATA_15
 (29 1) Enable bit of Mux _bram/lcb0_0 => lc_trk_g0_0 input0_0
 (29 1) Enable bit of Mux _bram/lcb0_0 => lc_trk_g0_2 input0_0
@@ -1921,11 +2234,16 @@
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g0_6 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_1 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_3 wire_bram/ram/WDATA_10
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_5 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_7 wire_bram/ram/WDATA_10
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g2_0 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g2_2 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g2_4 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g2_6 wire_bram/ram/WDATA_10
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g3_1 wire_bram/ram/WDATA_10
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g3_3 wire_bram/ram/WDATA_10
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g3_5 wire_bram/ram/WDATA_10
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g3_7 wire_bram/ram/WDATA_10
 (29 11) Enable bit of Mux _bram/lcb0_5 => lc_trk_g0_1 input0_5
 (29 11) Enable bit of Mux _bram/lcb0_5 => lc_trk_g0_3 input0_5
 (29 11) Enable bit of Mux _bram/lcb0_5 => lc_trk_g0_5 input0_5
@@ -1945,6 +2263,7 @@
 (29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g0_1 wire_bram/ram/WDATA_9
 (29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g0_3 wire_bram/ram/WDATA_9
 (29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g0_5 wire_bram/ram/WDATA_9
+(29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g0_7 wire_bram/ram/WDATA_9
 (29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g1_0 wire_bram/ram/WDATA_9
 (29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g1_2 wire_bram/ram/WDATA_9
 (29 12) Enable bit of Mux _bram/lcb1_6 => lc_trk_g1_4 wire_bram/ram/WDATA_9
@@ -1973,16 +2292,25 @@
 (29 13) Enable bit of Mux _bram/lcb0_6 => lc_trk_g3_3 input0_6
 (29 13) Enable bit of Mux _bram/lcb0_6 => lc_trk_g3_5 input0_6
 (29 13) Enable bit of Mux _bram/lcb0_6 => lc_trk_g3_7 input0_6
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g0_0 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g0_2 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g0_4 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g0_6 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_1 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_3 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_5 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_7 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g2_0 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g2_2 wire_bram/ram/WDATA_8
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g2_4 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g2_6 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g3_1 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g3_3 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g3_5 wire_bram/ram/WDATA_8
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g3_7 wire_bram/ram/WDATA_8
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g0_1 input0_7
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g0_3 input0_7
+(29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g0_5 input0_7
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g0_7 input0_7
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g1_0 input0_7
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g1_2 input0_7
@@ -1996,12 +2324,22 @@
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g3_2 input0_7
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g3_4 input0_7
 (29 15) Enable bit of Mux _bram/lcb0_7 => lc_trk_g3_6 input0_7
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_0 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_2 wire_bram/ram/WDATA_14
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_4 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_6 wire_bram/ram/WDATA_14
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_1 wire_bram/ram/WDATA_14
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_3 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_5 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_7 wire_bram/ram/WDATA_14
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g2_0 wire_bram/ram/WDATA_14
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g2_2 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g2_4 wire_bram/ram/WDATA_14
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g2_6 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g3_1 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g3_3 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g3_5 wire_bram/ram/WDATA_14
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g3_7 wire_bram/ram/WDATA_14
 (29 3) Enable bit of Mux _bram/lcb0_1 => lc_trk_g0_1 input0_1
 (29 3) Enable bit of Mux _bram/lcb0_1 => lc_trk_g0_3 input0_1
 (29 3) Enable bit of Mux _bram/lcb0_1 => lc_trk_g0_5 input0_1
@@ -2055,10 +2393,16 @@
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g0_4 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g0_6 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_1 wire_bram/ram/WDATA_12
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_3 wire_bram/ram/WDATA_12
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_5 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_7 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_0 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_2 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_4 wire_bram/ram/WDATA_12
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_6 wire_bram/ram/WDATA_12
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g3_1 wire_bram/ram/WDATA_12
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g3_3 wire_bram/ram/WDATA_12
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g3_5 wire_bram/ram/WDATA_12
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g3_7 wire_bram/ram/WDATA_12
 (29 7) Enable bit of Mux _bram/lcb0_3 => lc_trk_g0_1 input0_3
 (29 7) Enable bit of Mux _bram/lcb0_3 => lc_trk_g0_3 input0_3
@@ -2078,10 +2422,17 @@
 (29 7) Enable bit of Mux _bram/lcb0_3 => lc_trk_g3_6 input0_3
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_1 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_3 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_5 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_7 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g1_0 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g1_2 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g1_4 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g1_6 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g2_1 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g2_3 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g2_5 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g2_7 wire_bram/ram/WDATA_11
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g3_0 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g3_2 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g3_4 wire_bram/ram/WDATA_11
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g3_6 wire_bram/ram/WDATA_11
@@ -2105,10 +2456,13 @@
 (3 0) routing sp12_v_t_23 <X> sp12_v_b_0
 (3 1) routing sp12_h_l_23 <X> sp12_v_b_0
 (3 1) routing sp12_h_r_0 <X> sp12_v_b_0
+(3 10) routing sp12_h_r_1 <X> sp12_h_l_22
 (3 10) routing sp12_v_t_22 <X> sp12_h_l_22
+(3 11) routing sp12_h_r_1 <X> sp12_h_l_22
 (3 11) routing sp12_v_b_1 <X> sp12_h_l_22
 (3 12) routing sp12_v_b_1 <X> sp12_h_r_1
 (3 12) routing sp12_v_t_22 <X> sp12_h_r_1
+(3 13) routing sp12_h_l_22 <X> sp12_h_r_1
 (3 13) routing sp12_v_b_1 <X> sp12_h_r_1
 (3 14) routing sp12_h_r_1 <X> sp12_v_t_22
 (3 14) routing sp12_v_b_1 <X> sp12_v_t_22
@@ -2120,6 +2474,7 @@
 (3 3) routing sp12_v_b_0 <X> sp12_h_l_23
 (3 4) routing sp12_v_b_0 <X> sp12_h_r_0
 (3 4) routing sp12_v_t_23 <X> sp12_h_r_0
+(3 5) routing sp12_h_l_23 <X> sp12_h_r_0
 (3 5) routing sp12_v_b_0 <X> sp12_h_r_0
 (3 6) routing sp12_h_r_0 <X> sp12_v_t_23
 (3 6) routing sp12_v_b_0 <X> sp12_v_t_23
@@ -2130,26 +2485,39 @@
 (3 9) routing sp12_h_l_22 <X> sp12_v_b_1
 (3 9) routing sp12_h_r_1 <X> sp12_v_b_1
 (30 0) routing lc_trk_g0_5 <X> wire_bram/ram/WDATA_15
+(30 0) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_15
 (30 0) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_15
+(30 0) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_15
 (30 0) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_15
+(30 0) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_15
+(30 0) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_15
 (30 0) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_15
 (30 1) routing lc_trk_g0_3 <X> wire_bram/ram/WDATA_15
+(30 1) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_15
+(30 1) routing lc_trk_g1_2 <X> wire_bram/ram/WDATA_15
+(30 1) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_15
 (30 1) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_15
+(30 1) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_15
 (30 1) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_15
 (30 1) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_15
 (30 10) routing lc_trk_g0_4 <X> wire_bram/ram/WDATA_10
 (30 10) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_10
+(30 10) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_10
 (30 10) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_10
 (30 10) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_10
 (30 10) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_10
 (30 10) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_10
+(30 10) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_10
 (30 11) routing lc_trk_g0_2 <X> wire_bram/ram/WDATA_10
 (30 11) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_10
 (30 11) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_10
 (30 11) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_10
 (30 11) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_10
 (30 11) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_10
+(30 11) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_10
+(30 11) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_10
 (30 12) routing lc_trk_g0_5 <X> wire_bram/ram/WDATA_9
+(30 12) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_9
 (30 12) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_9
 (30 12) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_9
 (30 12) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_9
@@ -2157,6 +2525,7 @@
 (30 12) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_9
 (30 12) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_9
 (30 13) routing lc_trk_g0_3 <X> wire_bram/ram/WDATA_9
+(30 13) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_9
 (30 13) routing lc_trk_g1_2 <X> wire_bram/ram/WDATA_9
 (30 13) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_9
 (30 13) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_9
@@ -2166,16 +2535,35 @@
 (30 14) routing lc_trk_g0_4 <X> wire_bram/ram/WDATA_8
 (30 14) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_8
 (30 14) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_8
+(30 14) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_8
 (30 14) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_8
+(30 14) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_8
+(30 14) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_8
+(30 14) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_8
 (30 15) routing lc_trk_g0_2 <X> wire_bram/ram/WDATA_8
 (30 15) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_8
 (30 15) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_8
+(30 15) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_8
 (30 15) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_8
+(30 15) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_8
+(30 15) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_8
+(30 15) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_8
 (30 2) routing lc_trk_g0_4 <X> wire_bram/ram/WDATA_14
+(30 2) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_14
+(30 2) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_14
+(30 2) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_14
+(30 2) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_14
 (30 2) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_14
+(30 2) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_14
+(30 2) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_14
+(30 3) routing lc_trk_g0_2 <X> wire_bram/ram/WDATA_14
+(30 3) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_14
 (30 3) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_14
+(30 3) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_14
 (30 3) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_14
 (30 3) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_14
+(30 3) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_14
+(30 3) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_14
 (30 4) routing lc_trk_g0_5 <X> wire_bram/ram/WDATA_13
 (30 4) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_13
 (30 4) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_13
@@ -2194,70 +2582,108 @@
 (30 5) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_13
 (30 6) routing lc_trk_g0_4 <X> wire_bram/ram/WDATA_12
 (30 6) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_12
+(30 6) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_12
 (30 6) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_12
 (30 6) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_12
+(30 6) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_12
+(30 6) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_12
 (30 6) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_12
 (30 7) routing lc_trk_g0_2 <X> wire_bram/ram/WDATA_12
 (30 7) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_12
+(30 7) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_12
 (30 7) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_12
 (30 7) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_12
+(30 7) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_12
+(30 7) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_12
 (30 7) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_12
+(30 8) routing lc_trk_g0_5 <X> wire_bram/ram/WDATA_11
 (30 8) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_11
+(30 8) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_11
+(30 8) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_11
+(30 8) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_11
 (30 8) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_11
 (30 8) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_11
 (30 8) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g0_3 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g1_2 <X> wire_bram/ram/WDATA_11
+(30 9) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_11
 (30 9) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_11
+(31 0) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_15
 (31 0) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_15
 (31 0) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_15
 (31 0) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_15
+(31 0) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_15
+(31 0) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_15
+(31 0) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_15
 (31 0) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_15
+(31 1) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_15
 (31 1) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_15
 (31 1) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_15
 (31 1) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_15
 (31 1) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_15
+(31 1) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_15
 (31 1) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_15
 (31 1) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_15
 (31 10) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_10
+(31 10) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_10
 (31 10) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_10
 (31 10) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_10
 (31 10) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_10
 (31 10) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_10
 (31 10) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_10
+(31 10) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_10
 (31 11) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_10
+(31 11) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_10
 (31 11) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_10
 (31 11) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_10
 (31 11) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_10
 (31 11) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_10
+(31 11) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_10
+(31 11) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_10
 (31 12) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_9
+(31 12) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_9
+(31 12) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_9
 (31 12) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_9
 (31 12) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_9
 (31 12) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_9
 (31 12) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_9
+(31 12) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_9
 (31 13) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_9
+(31 13) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_9
 (31 13) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_9
 (31 13) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_9
 (31 13) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_9
 (31 13) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_9
 (31 13) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_9
+(31 13) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_9
 (31 14) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_8
+(31 14) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_8
+(31 14) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_8
+(31 14) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_8
 (31 14) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_8
 (31 14) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_8
 (31 14) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_8
+(31 14) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_8
+(31 15) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_8
+(31 15) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_8
 (31 15) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_8
+(31 15) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_8
 (31 15) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_8
 (31 15) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_8
 (31 15) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_8
+(31 15) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_8
 (31 2) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_14
 (31 2) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_14
+(31 2) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_14
 (31 2) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_14
+(31 2) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_14
 (31 2) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_14
 (31 2) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_14
+(31 2) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_14
 (31 3) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_14
 (31 3) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_14
 (31 3) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_14
@@ -2265,64 +2691,107 @@
 (31 3) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_14
 (31 3) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_14
 (31 3) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_14
+(31 3) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_14
+(31 4) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_13
 (31 4) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_13
 (31 4) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_13
 (31 4) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_13
+(31 4) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_13
 (31 4) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_13
 (31 4) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_13
 (31 4) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_13
 (31 5) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_13
 (31 5) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_13
+(31 5) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_13
 (31 5) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_13
+(31 5) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_13
 (31 5) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_13
+(31 5) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_13
 (31 5) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_13
 (31 6) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_12
 (31 6) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_12
+(31 6) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_12
 (31 6) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_12
 (31 6) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_12
+(31 6) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_12
+(31 6) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_12
 (31 6) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_12
+(31 7) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_12
 (31 7) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_12
 (31 7) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_12
 (31 7) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_12
+(31 7) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_12
+(31 7) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_12
+(31 7) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_12
 (31 7) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_12
 (31 8) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_11
+(31 8) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_11
 (31 8) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_11
 (31 8) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_11
 (31 8) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_11
+(31 8) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_11
 (31 8) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_11
+(31 8) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_11
 (31 9) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_11
+(31 9) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_11
+(31 9) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_11
 (31 9) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_11
 (31 9) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_11
+(31 9) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_11
 (31 9) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_11
+(31 9) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_11
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g0_3 wire_bram/ram/MASK_15
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g0_5 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g0_7 wire_bram/ram/MASK_15
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_0 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_2 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_4 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_6 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_1 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_3 wire_bram/ram/MASK_15
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_5 wire_bram/ram/MASK_15
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_7 wire_bram/ram/MASK_15
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_0 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_2 wire_bram/ram/MASK_15
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_4 wire_bram/ram/MASK_15
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_6 wire_bram/ram/MASK_15
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g0_2 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g0_4 wire_bram/ram/MASK_10
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g0_6 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_1 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_3 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_5 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_7 wire_bram/ram/MASK_10
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_0 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_2 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_4 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_6 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_1 wire_bram/ram/MASK_10
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_3 wire_bram/ram/MASK_10
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_5 wire_bram/ram/MASK_10
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_7 wire_bram/ram/MASK_10
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_1 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_3 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_5 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_7 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_0 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_2 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_4 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_6 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_1 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_3 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_5 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_7 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_0 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_2 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_4 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_6 input2_5
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g0_3 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g0_5 wire_bram/ram/MASK_9
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g0_7 wire_bram/ram/MASK_9
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_0 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_2 wire_bram/ram/MASK_9
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_4 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_6 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g2_1 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g2_3 wire_bram/ram/MASK_9
@@ -2331,6 +2800,7 @@
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g3_0 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g3_2 wire_bram/ram/MASK_9
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g3_4 wire_bram/ram/MASK_9
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g3_6 wire_bram/ram/MASK_9
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g0_0 input2_6
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g0_2 input2_6
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g0_4 input2_6
@@ -2347,8 +2817,13 @@
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g3_3 input2_6
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g3_5 input2_6
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g3_7 input2_6
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g0_2 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g0_4 wire_bram/ram/MASK_8
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g0_6 wire_bram/ram/MASK_8
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_1 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_3 wire_bram/ram/MASK_8
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_5 wire_bram/ram/MASK_8
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_7 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_0 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_2 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_4 wire_bram/ram/MASK_8
@@ -2356,6 +2831,7 @@
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g3_1 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g3_3 wire_bram/ram/MASK_8
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g3_5 wire_bram/ram/MASK_8
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g3_7 wire_bram/ram/MASK_8
 (32 15) Enable bit of Mux _bram/lcb2_7 => lc_trk_g0_1 input2_7
 (32 15) Enable bit of Mux _bram/lcb2_7 => lc_trk_g0_3 input2_7
 (32 15) Enable bit of Mux _bram/lcb2_7 => lc_trk_g0_5 input2_7
@@ -2377,49 +2853,85 @@
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g0_6 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_1 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_3 wire_bram/ram/MASK_14
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_5 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_7 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_0 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_2 wire_bram/ram/MASK_14
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_4 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_6 wire_bram/ram/MASK_14
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_1 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_3 wire_bram/ram/MASK_14
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_5 wire_bram/ram/MASK_14
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_7 wire_bram/ram/MASK_14
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g0_3 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g0_5 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g0_7 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_0 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_2 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_4 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_6 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_1 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_3 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_5 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_7 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_0 wire_bram/ram/MASK_13
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_2 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_4 wire_bram/ram/MASK_13
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_6 wire_bram/ram/MASK_13
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g0_2 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g0_4 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g0_6 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_1 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_3 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_5 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_7 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_0 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_2 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_4 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_6 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_1 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_3 wire_bram/ram/MASK_12
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_5 wire_bram/ram/MASK_12
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_7 wire_bram/ram/MASK_12
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g0_3 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g0_5 wire_bram/ram/MASK_11
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g0_7 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_0 wire_bram/ram/MASK_11
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_2 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_4 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_6 wire_bram/ram/MASK_11
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_1 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_3 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_5 wire_bram/ram/MASK_11
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_7 wire_bram/ram/MASK_11
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_0 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_2 wire_bram/ram/MASK_11
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_4 wire_bram/ram/MASK_11
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_6 wire_bram/ram/MASK_11
 (33 0) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_15
 (33 0) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_15
+(33 0) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_15
+(33 0) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_15
+(33 0) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_15
 (33 0) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_15
+(33 0) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_15
 (33 0) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_15
+(33 10) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_10
 (33 10) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_10
 (33 10) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_10
 (33 10) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_10
 (33 10) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_10
+(33 10) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_10
 (33 10) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_10
+(33 10) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_10
 (33 11) routing lc_trk_g2_1 <X> input2_5
+(33 11) routing lc_trk_g2_3 <X> input2_5
 (33 11) routing lc_trk_g2_5 <X> input2_5
+(33 11) routing lc_trk_g2_7 <X> input2_5
 (33 11) routing lc_trk_g3_0 <X> input2_5
+(33 11) routing lc_trk_g3_2 <X> input2_5
 (33 11) routing lc_trk_g3_4 <X> input2_5
+(33 11) routing lc_trk_g3_6 <X> input2_5
 (33 12) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_9
 (33 12) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_9
 (33 12) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_9
@@ -2427,6 +2939,7 @@
 (33 12) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_9
 (33 12) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_9
 (33 12) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_9
+(33 12) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_9
 (33 13) routing lc_trk_g2_0 <X> input2_6
 (33 13) routing lc_trk_g2_2 <X> input2_6
 (33 13) routing lc_trk_g2_4 <X> input2_6
@@ -2442,6 +2955,7 @@
 (33 14) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_8
 (33 14) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_8
 (33 14) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_8
+(33 14) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_8
 (33 15) routing lc_trk_g2_1 <X> input2_7
 (33 15) routing lc_trk_g2_3 <X> input2_7
 (33 15) routing lc_trk_g2_5 <X> input2_7
@@ -2452,40 +2966,68 @@
 (33 15) routing lc_trk_g3_6 <X> input2_7
 (33 2) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_14
 (33 2) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_14
+(33 2) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_14
 (33 2) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_14
+(33 2) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_14
 (33 2) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_14
 (33 2) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_14
+(33 2) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_14
+(33 4) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_13
+(33 4) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_13
+(33 4) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_13
 (33 4) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_13
 (33 4) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_13
+(33 4) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_13
 (33 4) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_13
 (33 4) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_13
+(33 6) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_12
+(33 6) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_12
 (33 6) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_12
+(33 6) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_12
 (33 6) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_12
+(33 6) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_12
+(33 6) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_12
 (33 6) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_12
+(33 8) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_11
 (33 8) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_11
 (33 8) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_11
+(33 8) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_11
+(33 8) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_11
 (33 8) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_11
 (33 8) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_11
+(33 8) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_11
+(34 0) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_15
 (34 0) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_15
 (34 0) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_15
 (34 0) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_15
+(34 0) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_15
 (34 0) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_15
+(34 0) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_15
 (34 0) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_15
 (34 10) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_10
 (34 10) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_10
 (34 10) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_10
 (34 10) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_10
 (34 10) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_10
+(34 10) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_10
 (34 10) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_10
+(34 10) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_10
 (34 11) routing lc_trk_g1_0 <X> input2_5
+(34 11) routing lc_trk_g1_2 <X> input2_5
+(34 11) routing lc_trk_g1_4 <X> input2_5
 (34 11) routing lc_trk_g1_6 <X> input2_5
 (34 11) routing lc_trk_g3_0 <X> input2_5
+(34 11) routing lc_trk_g3_2 <X> input2_5
 (34 11) routing lc_trk_g3_4 <X> input2_5
+(34 11) routing lc_trk_g3_6 <X> input2_5
+(34 12) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_9
 (34 12) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_9
+(34 12) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_9
 (34 12) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_9
 (34 12) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_9
 (34 12) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_9
 (34 12) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_9
+(34 12) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_9
 (34 13) routing lc_trk_g1_1 <X> input2_6
 (34 13) routing lc_trk_g1_3 <X> input2_6
 (34 13) routing lc_trk_g1_5 <X> input2_6
@@ -2494,10 +3036,14 @@
 (34 13) routing lc_trk_g3_3 <X> input2_6
 (34 13) routing lc_trk_g3_5 <X> input2_6
 (34 13) routing lc_trk_g3_7 <X> input2_6
+(34 14) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_8
 (34 14) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_8
+(34 14) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_8
+(34 14) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_8
 (34 14) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_8
 (34 14) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_8
 (34 14) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_8
+(34 14) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_8
 (34 15) routing lc_trk_g1_0 <X> input2_7
 (34 15) routing lc_trk_g1_2 <X> input2_7
 (34 15) routing lc_trk_g1_4 <X> input2_7
@@ -2508,28 +3054,52 @@
 (34 15) routing lc_trk_g3_6 <X> input2_7
 (34 2) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_14
 (34 2) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_14
+(34 2) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_14
 (34 2) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_14
+(34 2) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_14
 (34 2) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_14
 (34 2) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_14
+(34 2) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_14
+(34 4) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_13
+(34 4) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_13
 (34 4) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_13
 (34 4) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_13
 (34 4) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_13
+(34 4) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_13
 (34 4) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_13
 (34 4) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_13
+(34 6) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_12
 (34 6) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_12
+(34 6) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_12
 (34 6) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_12
 (34 6) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_12
+(34 6) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_12
+(34 6) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_12
 (34 6) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_12
 (34 8) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_11
+(34 8) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_11
 (34 8) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_11
 (34 8) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_11
+(34 8) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_11
 (34 8) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_11
 (34 8) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_11
+(34 8) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_11
+(35 10) routing lc_trk_g0_5 <X> input2_5
+(35 10) routing lc_trk_g0_7 <X> input2_5
+(35 10) routing lc_trk_g1_4 <X> input2_5
 (35 10) routing lc_trk_g1_6 <X> input2_5
 (35 10) routing lc_trk_g2_5 <X> input2_5
+(35 10) routing lc_trk_g2_7 <X> input2_5
 (35 10) routing lc_trk_g3_4 <X> input2_5
+(35 10) routing lc_trk_g3_6 <X> input2_5
 (35 11) routing lc_trk_g0_3 <X> input2_5
+(35 11) routing lc_trk_g0_7 <X> input2_5
+(35 11) routing lc_trk_g1_2 <X> input2_5
 (35 11) routing lc_trk_g1_6 <X> input2_5
+(35 11) routing lc_trk_g2_3 <X> input2_5
+(35 11) routing lc_trk_g2_7 <X> input2_5
+(35 11) routing lc_trk_g3_2 <X> input2_5
+(35 11) routing lc_trk_g3_6 <X> input2_5
 (35 12) routing lc_trk_g0_4 <X> input2_6
 (35 12) routing lc_trk_g0_6 <X> input2_6
 (35 12) routing lc_trk_g1_5 <X> input2_6
@@ -2565,13 +3135,18 @@
 (36 0) Enable bit of Mux _out_links/OutMux8_0 => wire_bram/ram/RDATA_15 sp4_h_r_32
 (36 1) Enable bit of Mux _out_links/OutMux6_0 => wire_bram/ram/RDATA_15 sp4_h_r_0
 (36 10) Enable bit of Mux _out_links/OutMux8_5 => wire_bram/ram/RDATA_10 sp4_h_r_42
+(36 11) Enable bit of Mux _out_links/OutMux6_5 => wire_bram/ram/RDATA_10 sp4_h_r_10
 (36 12) Enable bit of Mux _out_links/OutMux8_6 => wire_bram/ram/RDATA_9 sp4_h_r_44
 (36 13) Enable bit of Mux _out_links/OutMux6_6 => wire_bram/ram/RDATA_9 sp4_h_l_1
+(36 14) Enable bit of Mux _out_links/OutMux8_7 => wire_bram/ram/RDATA_8 sp4_h_r_46
 (36 15) Enable bit of Mux _out_links/OutMux6_7 => wire_bram/ram/RDATA_8 sp4_h_l_3
 (36 2) Enable bit of Mux _out_links/OutMux8_1 => wire_bram/ram/RDATA_14 sp4_h_r_34
+(36 3) Enable bit of Mux _out_links/OutMux6_1 => wire_bram/ram/RDATA_14 sp4_h_r_2
 (36 4) Enable bit of Mux _out_links/OutMux8_2 => wire_bram/ram/RDATA_13 sp4_h_r_36
+(36 5) Enable bit of Mux _out_links/OutMux6_2 => wire_bram/ram/RDATA_13 sp4_h_r_4
 (36 6) Enable bit of Mux _out_links/OutMux8_3 => wire_bram/ram/RDATA_12 sp4_h_l_27
 (36 7) Enable bit of Mux _out_links/OutMux6_3 => wire_bram/ram/RDATA_12 sp4_h_r_6
+(36 8) Enable bit of Mux _out_links/OutMux8_4 => wire_bram/ram/RDATA_11 sp4_h_r_40
 (36 9) Enable bit of Mux _out_links/OutMux6_4 => wire_bram/ram/RDATA_11 sp4_h_r_8
 (37 0) Enable bit of Mux _out_links/OutMux5_0 => wire_bram/ram/RDATA_15 sp12_h_r_8
 (37 1) Enable bit of Mux _out_links/OutMux7_0 => wire_bram/ram/RDATA_15 sp4_h_r_16
@@ -2586,10 +3161,13 @@
 (37 4) Enable bit of Mux _out_links/OutMux5_2 => wire_bram/ram/RDATA_13 sp12_h_r_12
 (37 5) Enable bit of Mux _out_links/OutMux7_2 => wire_bram/ram/RDATA_13 sp4_h_l_9
 (37 6) Enable bit of Mux _out_links/OutMux5_3 => wire_bram/ram/RDATA_12 sp12_h_r_14
+(37 7) Enable bit of Mux _out_links/OutMux7_3 => wire_bram/ram/RDATA_12 sp4_h_l_11
 (37 8) Enable bit of Mux _out_links/OutMux4_4 => wire_bram/ram/RDATA_11 sp12_h_r_0
 (37 9) Enable bit of Mux _out_links/OutMux7_4 => wire_bram/ram/RDATA_11 sp4_h_r_24
 (38 0) Enable bit of Mux _out_links/OutMux2_0 => wire_bram/ram/RDATA_15 sp4_v_b_32
+(38 1) Enable bit of Mux _out_links/OutMux0_0 => wire_bram/ram/RDATA_15 sp4_v_b_0
 (38 10) Enable bit of Mux _out_links/OutMux1_5 => wire_bram/ram/RDATA_10 sp4_v_t_15
+(38 11) Enable bit of Mux _out_links/OutMux5_5 => wire_bram/ram/RDATA_10 sp12_h_l_17
 (38 12) Enable bit of Mux _out_links/OutMux1_6 => wire_bram/ram/RDATA_9 sp4_v_b_28
 (38 13) Enable bit of Mux _out_links/OutMux5_6 => wire_bram/ram/RDATA_9 sp12_h_r_20
 (38 14) Enable bit of Mux _out_links/OutMux1_7 => wire_bram/ram/RDATA_8 sp4_v_t_19
@@ -2601,6 +3179,7 @@
 (38 6) Enable bit of Mux _out_links/OutMux2_3 => wire_bram/ram/RDATA_12 sp4_v_t_27
 (38 7) Enable bit of Mux _out_links/OutMux0_3 => wire_bram/ram/RDATA_12 sp4_v_b_6
 (38 8) Enable bit of Mux _out_links/OutMux1_4 => wire_bram/ram/RDATA_11 sp4_v_t_13
+(38 9) Enable bit of Mux _out_links/OutMux5_4 => wire_bram/ram/RDATA_11 sp12_h_l_15
 (39 0) Enable bit of Mux _out_links/OutMux3_0 => wire_bram/ram/RDATA_15 sp12_v_b_0
 (39 1) Enable bit of Mux _out_links/OutMux1_0 => wire_bram/ram/RDATA_15 sp4_v_b_16
 (39 10) Enable bit of Mux _out_links/OutMux2_5 => wire_bram/ram/RDATA_10 sp4_v_t_31
@@ -2621,12 +3200,15 @@
 (4 0) routing sp4_h_l_43 <X> sp4_v_b_0
 (4 0) routing sp4_v_t_37 <X> sp4_v_b_0
 (4 0) routing sp4_v_t_41 <X> sp4_v_b_0
+(4 1) routing sp4_h_l_41 <X> sp4_h_r_0
 (4 1) routing sp4_h_l_44 <X> sp4_h_r_0
 (4 1) routing sp4_v_b_6 <X> sp4_h_r_0
+(4 1) routing sp4_v_t_42 <X> sp4_h_r_0
 (4 10) routing sp4_h_r_0 <X> sp4_v_t_43
 (4 10) routing sp4_h_r_6 <X> sp4_v_t_43
 (4 10) routing sp4_v_b_10 <X> sp4_v_t_43
 (4 10) routing sp4_v_b_6 <X> sp4_v_t_43
+(4 11) routing sp4_h_r_10 <X> sp4_h_l_43
 (4 11) routing sp4_h_r_3 <X> sp4_h_l_43
 (4 11) routing sp4_v_b_1 <X> sp4_h_l_43
 (4 11) routing sp4_v_t_37 <X> sp4_h_l_43
@@ -2634,11 +3216,16 @@
 (4 12) routing sp4_h_l_44 <X> sp4_v_b_9
 (4 12) routing sp4_v_t_36 <X> sp4_v_b_9
 (4 12) routing sp4_v_t_44 <X> sp4_v_b_9
+(4 13) routing sp4_h_l_36 <X> sp4_h_r_9
+(4 13) routing sp4_h_l_43 <X> sp4_h_r_9
+(4 13) routing sp4_v_b_3 <X> sp4_h_r_9
 (4 13) routing sp4_v_t_41 <X> sp4_h_r_9
 (4 14) routing sp4_h_r_3 <X> sp4_v_t_44
 (4 14) routing sp4_h_r_9 <X> sp4_v_t_44
 (4 14) routing sp4_v_b_1 <X> sp4_v_t_44
 (4 14) routing sp4_v_b_9 <X> sp4_v_t_44
+(4 15) routing sp4_h_r_1 <X> sp4_h_l_44
+(4 15) routing sp4_h_r_6 <X> sp4_h_l_44
 (4 15) routing sp4_v_b_4 <X> sp4_h_l_44
 (4 15) routing sp4_v_t_38 <X> sp4_h_l_44
 (4 2) routing sp4_h_r_0 <X> sp4_v_t_37
@@ -2653,44 +3240,58 @@
 (4 4) routing sp4_h_l_44 <X> sp4_v_b_3
 (4 4) routing sp4_v_t_38 <X> sp4_v_b_3
 (4 4) routing sp4_v_t_42 <X> sp4_v_b_3
+(4 5) routing sp4_h_l_37 <X> sp4_h_r_3
+(4 5) routing sp4_h_l_42 <X> sp4_h_r_3
 (4 5) routing sp4_v_b_9 <X> sp4_h_r_3
 (4 5) routing sp4_v_t_47 <X> sp4_h_r_3
 (4 6) routing sp4_h_r_3 <X> sp4_v_t_38
 (4 6) routing sp4_h_r_9 <X> sp4_v_t_38
 (4 6) routing sp4_v_b_3 <X> sp4_v_t_38
 (4 6) routing sp4_v_b_7 <X> sp4_v_t_38
+(4 7) routing sp4_h_r_0 <X> sp4_h_l_38
+(4 7) routing sp4_h_r_7 <X> sp4_h_l_38
 (4 7) routing sp4_v_b_10 <X> sp4_h_l_38
 (4 7) routing sp4_v_t_44 <X> sp4_h_l_38
 (4 8) routing sp4_h_l_37 <X> sp4_v_b_6
 (4 8) routing sp4_h_l_43 <X> sp4_v_b_6
 (4 8) routing sp4_v_t_43 <X> sp4_v_b_6
 (4 8) routing sp4_v_t_47 <X> sp4_v_b_6
+(4 9) routing sp4_h_l_38 <X> sp4_h_r_6
+(4 9) routing sp4_h_l_47 <X> sp4_h_r_6
 (4 9) routing sp4_v_b_0 <X> sp4_h_r_6
 (4 9) routing sp4_v_t_36 <X> sp4_h_r_6
 (40 0) Enable bit of Mux _out_links/OutMuxa_0 => wire_bram/ram/RDATA_15 sp4_r_v_b_17
 (40 1) Enable bit of Mux _out_links/OutMux4_0 => wire_bram/ram/RDATA_15 sp12_v_b_16
 (40 10) Enable bit of Mux _out_links/OutMuxa_5 => wire_bram/ram/RDATA_10 sp4_r_v_b_27
 (40 11) Enable bit of Mux _out_links/OutMux3_5 => wire_bram/ram/RDATA_10 sp12_v_b_10
+(40 12) Enable bit of Mux _out_links/OutMuxa_6 => wire_bram/ram/RDATA_9 sp4_r_v_b_29
 (40 13) Enable bit of Mux _out_links/OutMux3_6 => wire_bram/ram/RDATA_9 sp12_v_t_11
+(40 14) Enable bit of Mux _out_links/OutMuxa_7 => wire_bram/ram/RDATA_8 sp4_r_v_b_31
 (40 15) Enable bit of Mux _out_links/OutMux3_7 => wire_bram/ram/RDATA_8 sp12_v_b_14
 (40 2) Enable bit of Mux _out_links/OutMuxa_1 => wire_bram/ram/RDATA_14 sp4_r_v_b_19
 (40 3) Enable bit of Mux _out_links/OutMux4_1 => wire_bram/ram/RDATA_14 sp12_v_b_18
 (40 4) Enable bit of Mux _out_links/OutMuxa_2 => wire_bram/ram/RDATA_13 sp4_r_v_b_21
 (40 5) Enable bit of Mux _out_links/OutMux4_2 => wire_bram/ram/RDATA_13 sp12_v_b_20
+(40 6) Enable bit of Mux _out_links/OutMuxa_3 => wire_bram/ram/RDATA_12 sp4_r_v_b_23
 (40 7) Enable bit of Mux _out_links/OutMux4_3 => wire_bram/ram/RDATA_12 sp12_v_b_22
+(40 8) Enable bit of Mux _out_links/OutMuxa_4 => wire_bram/ram/RDATA_11 sp4_r_v_b_25
 (40 9) Enable bit of Mux _out_links/OutMux3_4 => wire_bram/ram/RDATA_11 sp12_v_t_7
 (41 0) Enable bit of Mux _out_links/OutMuxb_0 => wire_bram/ram/RDATA_15 sp4_r_v_b_33
+(41 1) Enable bit of Mux _out_links/OutMux9_0 => wire_bram/ram/RDATA_15 sp4_r_v_b_1
+(41 10) Enable bit of Mux _out_links/OutMuxb_5 => wire_bram/ram/RDATA_10 sp4_r_v_b_43
 (41 11) Enable bit of Mux _out_links/OutMux9_5 => wire_bram/ram/RDATA_10 sp4_r_v_b_11
 (41 12) Enable bit of Mux _out_links/OutMuxb_6 => wire_bram/ram/RDATA_9 sp4_r_v_b_45
 (41 13) Enable bit of Mux _out_links/OutMux9_6 => wire_bram/ram/RDATA_9 sp4_r_v_b_13
 (41 14) Enable bit of Mux _out_links/OutMuxb_7 => wire_bram/ram/RDATA_8 sp4_r_v_b_47
 (41 15) Enable bit of Mux _out_links/OutMux9_7 => wire_bram/ram/RDATA_8 sp4_r_v_b_15
 (41 2) Enable bit of Mux _out_links/OutMuxb_1 => wire_bram/ram/RDATA_14 sp4_r_v_b_35
+(41 3) Enable bit of Mux _out_links/OutMux9_1 => wire_bram/ram/RDATA_14 sp4_r_v_b_3
 (41 4) Enable bit of Mux _out_links/OutMuxb_2 => wire_bram/ram/RDATA_13 sp4_r_v_b_37
 (41 5) Enable bit of Mux _out_links/OutMux9_2 => wire_bram/ram/RDATA_13 sp4_r_v_b_5
 (41 6) Enable bit of Mux _out_links/OutMuxb_3 => wire_bram/ram/RDATA_12 sp4_r_v_b_39
 (41 7) Enable bit of Mux _out_links/OutMux9_3 => wire_bram/ram/RDATA_12 sp4_r_v_b_7
 (41 8) Enable bit of Mux _out_links/OutMuxb_4 => wire_bram/ram/RDATA_11 sp4_r_v_b_41
+(41 9) Enable bit of Mux _out_links/OutMux9_4 => wire_bram/ram/RDATA_11 sp4_r_v_b_9
 (5 0) routing sp4_h_l_44 <X> sp4_h_r_0
 (5 0) routing sp4_v_b_0 <X> sp4_h_r_0
 (5 0) routing sp4_v_b_6 <X> sp4_h_r_0
@@ -2707,11 +3308,15 @@
 (5 11) routing sp4_h_r_0 <X> sp4_v_t_43
 (5 11) routing sp4_h_r_6 <X> sp4_v_t_43
 (5 11) routing sp4_v_b_3 <X> sp4_v_t_43
+(5 12) routing sp4_h_l_43 <X> sp4_h_r_9
+(5 12) routing sp4_v_b_3 <X> sp4_h_r_9
 (5 12) routing sp4_v_b_9 <X> sp4_h_r_9
+(5 12) routing sp4_v_t_44 <X> sp4_h_r_9
 (5 13) routing sp4_h_l_38 <X> sp4_v_b_9
 (5 13) routing sp4_h_l_44 <X> sp4_v_b_9
 (5 13) routing sp4_h_r_9 <X> sp4_v_b_9
 (5 13) routing sp4_v_t_43 <X> sp4_v_b_9
+(5 14) routing sp4_h_r_6 <X> sp4_h_l_44
 (5 14) routing sp4_v_b_9 <X> sp4_h_l_44
 (5 14) routing sp4_v_t_38 <X> sp4_h_l_44
 (5 14) routing sp4_v_t_44 <X> sp4_h_l_44
@@ -2727,12 +3332,15 @@
 (5 3) routing sp4_h_r_0 <X> sp4_v_t_37
 (5 3) routing sp4_h_r_6 <X> sp4_v_t_37
 (5 3) routing sp4_v_b_9 <X> sp4_v_t_37
+(5 4) routing sp4_h_l_37 <X> sp4_h_r_3
+(5 4) routing sp4_v_b_3 <X> sp4_h_r_3
 (5 4) routing sp4_v_b_9 <X> sp4_h_r_3
 (5 4) routing sp4_v_t_38 <X> sp4_h_r_3
 (5 5) routing sp4_h_l_38 <X> sp4_v_b_3
 (5 5) routing sp4_h_l_44 <X> sp4_v_b_3
 (5 5) routing sp4_h_r_3 <X> sp4_v_b_3
 (5 5) routing sp4_v_t_37 <X> sp4_v_b_3
+(5 6) routing sp4_h_r_0 <X> sp4_h_l_38
 (5 6) routing sp4_v_b_3 <X> sp4_h_l_38
 (5 6) routing sp4_v_t_38 <X> sp4_h_l_38
 (5 6) routing sp4_v_t_44 <X> sp4_h_l_38
@@ -2740,6 +3348,7 @@
 (5 7) routing sp4_h_r_3 <X> sp4_v_t_38
 (5 7) routing sp4_h_r_9 <X> sp4_v_t_38
 (5 7) routing sp4_v_b_0 <X> sp4_v_t_38
+(5 8) routing sp4_h_l_38 <X> sp4_h_r_6
 (5 8) routing sp4_v_b_0 <X> sp4_h_r_6
 (5 8) routing sp4_v_b_6 <X> sp4_h_r_6
 (5 8) routing sp4_v_t_43 <X> sp4_h_r_6
@@ -2751,12 +3360,15 @@
 (6 0) routing sp4_h_r_7 <X> sp4_v_b_0
 (6 0) routing sp4_v_t_41 <X> sp4_v_b_0
 (6 0) routing sp4_v_t_44 <X> sp4_v_b_0
+(6 1) routing sp4_h_l_37 <X> sp4_h_r_0
+(6 1) routing sp4_h_l_41 <X> sp4_h_r_0
 (6 1) routing sp4_v_b_0 <X> sp4_h_r_0
 (6 1) routing sp4_v_b_6 <X> sp4_h_r_0
 (6 10) routing sp4_h_l_36 <X> sp4_v_t_43
 (6 10) routing sp4_h_r_0 <X> sp4_v_t_43
 (6 10) routing sp4_v_b_10 <X> sp4_v_t_43
 (6 10) routing sp4_v_b_3 <X> sp4_v_t_43
+(6 11) routing sp4_h_r_10 <X> sp4_h_l_43
 (6 11) routing sp4_h_r_6 <X> sp4_h_l_43
 (6 11) routing sp4_v_t_37 <X> sp4_h_l_43
 (6 11) routing sp4_v_t_43 <X> sp4_h_l_43
@@ -2764,17 +3376,23 @@
 (6 12) routing sp4_h_r_4 <X> sp4_v_b_9
 (6 12) routing sp4_v_t_36 <X> sp4_v_b_9
 (6 12) routing sp4_v_t_43 <X> sp4_v_b_9
+(6 13) routing sp4_h_l_36 <X> sp4_h_r_9
+(6 13) routing sp4_h_l_44 <X> sp4_h_r_9
+(6 13) routing sp4_v_b_3 <X> sp4_h_r_9
 (6 13) routing sp4_v_b_9 <X> sp4_h_r_9
 (6 14) routing sp4_h_l_41 <X> sp4_v_t_44
 (6 14) routing sp4_h_r_3 <X> sp4_v_t_44
 (6 14) routing sp4_v_b_1 <X> sp4_v_t_44
 (6 14) routing sp4_v_b_6 <X> sp4_v_t_44
+(6 15) routing sp4_h_r_1 <X> sp4_h_l_44
+(6 15) routing sp4_h_r_9 <X> sp4_h_l_44
 (6 15) routing sp4_v_t_38 <X> sp4_h_l_44
 (6 15) routing sp4_v_t_44 <X> sp4_h_l_44
 (6 2) routing sp4_h_l_42 <X> sp4_v_t_37
 (6 2) routing sp4_h_r_6 <X> sp4_v_t_37
 (6 2) routing sp4_v_b_4 <X> sp4_v_t_37
 (6 2) routing sp4_v_b_9 <X> sp4_v_t_37
+(6 3) routing sp4_h_r_0 <X> sp4_h_l_37
 (6 3) routing sp4_h_r_4 <X> sp4_h_l_37
 (6 3) routing sp4_v_t_37 <X> sp4_h_l_37
 (6 3) routing sp4_v_t_43 <X> sp4_h_l_37
@@ -2782,18 +3400,24 @@
 (6 4) routing sp4_h_r_10 <X> sp4_v_b_3
 (6 4) routing sp4_v_t_37 <X> sp4_v_b_3
 (6 4) routing sp4_v_t_42 <X> sp4_v_b_3
+(6 5) routing sp4_h_l_38 <X> sp4_h_r_3
+(6 5) routing sp4_h_l_42 <X> sp4_h_r_3
+(6 5) routing sp4_v_b_3 <X> sp4_h_r_3
 (6 5) routing sp4_v_b_9 <X> sp4_h_r_3
 (6 6) routing sp4_h_l_47 <X> sp4_v_t_38
 (6 6) routing sp4_h_r_9 <X> sp4_v_t_38
 (6 6) routing sp4_v_b_0 <X> sp4_v_t_38
 (6 6) routing sp4_v_b_7 <X> sp4_v_t_38
 (6 7) routing sp4_h_r_3 <X> sp4_h_l_38
+(6 7) routing sp4_h_r_7 <X> sp4_h_l_38
 (6 7) routing sp4_v_t_38 <X> sp4_h_l_38
 (6 7) routing sp4_v_t_44 <X> sp4_h_l_38
 (6 8) routing sp4_h_l_37 <X> sp4_v_b_6
 (6 8) routing sp4_h_r_1 <X> sp4_v_b_6
 (6 8) routing sp4_v_t_38 <X> sp4_v_b_6
 (6 8) routing sp4_v_t_47 <X> sp4_v_b_6
+(6 9) routing sp4_h_l_43 <X> sp4_h_r_6
+(6 9) routing sp4_h_l_47 <X> sp4_h_r_6
 (6 9) routing sp4_v_b_0 <X> sp4_h_r_6
 (6 9) routing sp4_v_b_6 <X> sp4_h_r_6
 (7 1) Ram config bit: MEMB_Power_Up_Control
@@ -2813,18 +3437,23 @@
 (8 1) routing sp4_h_l_42 <X> sp4_v_b_1
 (8 1) routing sp4_h_r_1 <X> sp4_v_b_1
 (8 1) routing sp4_v_t_47 <X> sp4_v_b_1
+(8 10) routing sp4_h_r_11 <X> sp4_h_l_42
+(8 10) routing sp4_h_r_7 <X> sp4_h_l_42
 (8 10) routing sp4_v_t_36 <X> sp4_h_l_42
 (8 10) routing sp4_v_t_42 <X> sp4_h_l_42
 (8 11) routing sp4_h_l_42 <X> sp4_v_t_42
 (8 11) routing sp4_h_r_1 <X> sp4_v_t_42
 (8 11) routing sp4_h_r_7 <X> sp4_v_t_42
 (8 11) routing sp4_v_b_4 <X> sp4_v_t_42
+(8 12) routing sp4_h_l_39 <X> sp4_h_r_10
 (8 12) routing sp4_h_l_47 <X> sp4_h_r_10
+(8 12) routing sp4_v_b_10 <X> sp4_h_r_10
 (8 12) routing sp4_v_b_4 <X> sp4_h_r_10
 (8 13) routing sp4_h_l_41 <X> sp4_v_b_10
 (8 13) routing sp4_h_l_47 <X> sp4_v_b_10
 (8 13) routing sp4_h_r_10 <X> sp4_v_b_10
 (8 13) routing sp4_v_t_42 <X> sp4_v_b_10
+(8 14) routing sp4_h_r_10 <X> sp4_h_l_47
 (8 14) routing sp4_h_r_2 <X> sp4_h_l_47
 (8 14) routing sp4_v_t_41 <X> sp4_h_l_47
 (8 14) routing sp4_v_t_47 <X> sp4_h_l_47
@@ -2832,28 +3461,39 @@
 (8 15) routing sp4_h_r_10 <X> sp4_v_t_47
 (8 15) routing sp4_h_r_4 <X> sp4_v_t_47
 (8 15) routing sp4_v_b_7 <X> sp4_v_t_47
+(8 2) routing sp4_h_r_1 <X> sp4_h_l_36
+(8 2) routing sp4_h_r_5 <X> sp4_h_l_36
 (8 2) routing sp4_v_t_36 <X> sp4_h_l_36
 (8 2) routing sp4_v_t_42 <X> sp4_h_l_36
 (8 3) routing sp4_h_l_36 <X> sp4_v_t_36
 (8 3) routing sp4_h_r_1 <X> sp4_v_t_36
 (8 3) routing sp4_h_r_7 <X> sp4_v_t_36
 (8 3) routing sp4_v_b_10 <X> sp4_v_t_36
+(8 4) routing sp4_h_l_41 <X> sp4_h_r_4
 (8 4) routing sp4_h_l_45 <X> sp4_h_r_4
+(8 4) routing sp4_v_b_10 <X> sp4_h_r_4
 (8 4) routing sp4_v_b_4 <X> sp4_h_r_4
 (8 5) routing sp4_h_l_41 <X> sp4_v_b_4
 (8 5) routing sp4_h_l_47 <X> sp4_v_b_4
 (8 5) routing sp4_h_r_4 <X> sp4_v_b_4
 (8 5) routing sp4_v_t_36 <X> sp4_v_b_4
 (8 6) routing sp4_h_r_4 <X> sp4_h_l_41
+(8 6) routing sp4_h_r_8 <X> sp4_h_l_41
 (8 6) routing sp4_v_t_41 <X> sp4_h_l_41
 (8 6) routing sp4_v_t_47 <X> sp4_h_l_41
 (8 7) routing sp4_h_l_41 <X> sp4_v_t_41
+(8 7) routing sp4_h_r_10 <X> sp4_v_t_41
 (8 7) routing sp4_h_r_4 <X> sp4_v_t_41
 (8 7) routing sp4_v_b_1 <X> sp4_v_t_41
+(8 8) routing sp4_h_l_42 <X> sp4_h_r_7
+(8 8) routing sp4_h_l_46 <X> sp4_h_r_7
+(8 8) routing sp4_v_b_1 <X> sp4_h_r_7
+(8 8) routing sp4_v_b_7 <X> sp4_h_r_7
 (8 9) routing sp4_h_l_36 <X> sp4_v_b_7
 (8 9) routing sp4_h_l_42 <X> sp4_v_b_7
 (8 9) routing sp4_h_r_7 <X> sp4_v_b_7
 (8 9) routing sp4_v_t_41 <X> sp4_v_b_7
+(9 0) routing sp4_h_l_47 <X> sp4_h_r_1
 (9 0) routing sp4_v_b_1 <X> sp4_h_r_1
 (9 0) routing sp4_v_b_7 <X> sp4_h_r_1
 (9 0) routing sp4_v_t_36 <X> sp4_h_r_1
@@ -2869,6 +3509,8 @@
 (9 11) routing sp4_h_r_7 <X> sp4_v_t_42
 (9 11) routing sp4_v_b_11 <X> sp4_v_t_42
 (9 11) routing sp4_v_b_7 <X> sp4_v_t_42
+(9 12) routing sp4_h_l_42 <X> sp4_h_r_10
+(9 12) routing sp4_v_b_10 <X> sp4_h_r_10
 (9 12) routing sp4_v_b_4 <X> sp4_h_r_10
 (9 12) routing sp4_v_t_47 <X> sp4_h_r_10
 (9 13) routing sp4_h_l_41 <X> sp4_v_b_10
@@ -2892,18 +3534,24 @@
 (9 3) routing sp4_v_b_1 <X> sp4_v_t_36
 (9 3) routing sp4_v_b_5 <X> sp4_v_t_36
 (9 4) routing sp4_h_l_36 <X> sp4_h_r_4
+(9 4) routing sp4_v_b_10 <X> sp4_h_r_4
 (9 4) routing sp4_v_b_4 <X> sp4_h_r_4
 (9 4) routing sp4_v_t_41 <X> sp4_h_r_4
 (9 5) routing sp4_h_l_41 <X> sp4_v_b_4
 (9 5) routing sp4_h_l_47 <X> sp4_v_b_4
 (9 5) routing sp4_v_t_41 <X> sp4_v_b_4
 (9 5) routing sp4_v_t_45 <X> sp4_v_b_4
+(9 6) routing sp4_h_r_1 <X> sp4_h_l_41
 (9 6) routing sp4_v_b_4 <X> sp4_h_l_41
 (9 6) routing sp4_v_t_41 <X> sp4_h_l_41
 (9 6) routing sp4_v_t_47 <X> sp4_h_l_41
+(9 7) routing sp4_h_r_10 <X> sp4_v_t_41
 (9 7) routing sp4_h_r_4 <X> sp4_v_t_41
 (9 7) routing sp4_v_b_4 <X> sp4_v_t_41
 (9 7) routing sp4_v_b_8 <X> sp4_v_t_41
+(9 8) routing sp4_h_l_41 <X> sp4_h_r_7
+(9 8) routing sp4_v_b_1 <X> sp4_h_r_7
+(9 8) routing sp4_v_b_7 <X> sp4_h_r_7
 (9 8) routing sp4_v_t_42 <X> sp4_h_r_7
 (9 9) routing sp4_h_l_36 <X> sp4_v_b_7
 (9 9) routing sp4_h_l_42 <X> sp4_v_b_7

--- a/icefuzz/cached_ramt_5k.txt
+++ b/icefuzz/cached_ramt_5k.txt
@@ -1,15 +1,33 @@
 (0 0) Negative Clock bit
+(0 10) routing glb_netwk_3 <X> glb2local_2
+(0 10) routing glb_netwk_6 <X> glb2local_2
+(0 10) routing glb_netwk_7 <X> glb2local_2
+(0 11) routing glb_netwk_1 <X> glb2local_2
+(0 11) routing glb_netwk_3 <X> glb2local_2
 (0 11) routing glb_netwk_5 <X> glb2local_2
+(0 11) routing glb_netwk_7 <X> glb2local_2
+(0 12) routing glb_netwk_3 <X> glb2local_3
+(0 12) routing glb_netwk_6 <X> glb2local_3
+(0 12) routing glb_netwk_7 <X> glb2local_3
+(0 13) routing glb_netwk_1 <X> glb2local_3
+(0 13) routing glb_netwk_3 <X> glb2local_3
 (0 13) routing glb_netwk_5 <X> glb2local_3
+(0 13) routing glb_netwk_7 <X> glb2local_3
 (0 14) routing glb_netwk_4 <X> wire_bram/ram/WE
+(0 14) routing glb_netwk_6 <X> wire_bram/ram/WE
 (0 14) routing lc_trk_g2_4 <X> wire_bram/ram/WE
 (0 14) routing lc_trk_g3_5 <X> wire_bram/ram/WE
+(0 15) routing glb_netwk_6 <X> wire_bram/ram/WE
 (0 15) routing lc_trk_g1_5 <X> wire_bram/ram/WE
 (0 15) routing lc_trk_g3_5 <X> wire_bram/ram/WE
 (0 2) routing glb_netwk_2 <X> wire_bram/ram/WCLK
+(0 2) routing glb_netwk_3 <X> wire_bram/ram/WCLK
+(0 2) routing glb_netwk_6 <X> wire_bram/ram/WCLK
 (0 2) routing glb_netwk_7 <X> wire_bram/ram/WCLK
 (0 2) routing lc_trk_g2_0 <X> wire_bram/ram/WCLK
 (0 2) routing lc_trk_g3_1 <X> wire_bram/ram/WCLK
+(0 3) routing glb_netwk_1 <X> wire_bram/ram/WCLK
+(0 3) routing glb_netwk_3 <X> wire_bram/ram/WCLK
 (0 3) routing glb_netwk_5 <X> wire_bram/ram/WCLK
 (0 3) routing glb_netwk_7 <X> wire_bram/ram/WCLK
 (0 3) routing lc_trk_g1_1 <X> wire_bram/ram/WCLK
@@ -21,17 +39,39 @@
 (0 5) routing lc_trk_g1_3 <X> wire_bram/ram/WCLKE
 (0 5) routing lc_trk_g3_3 <X> wire_bram/ram/WCLKE
 (0 6) routing glb_netwk_3 <X> glb2local_0
+(0 6) routing glb_netwk_6 <X> glb2local_0
+(0 6) routing glb_netwk_7 <X> glb2local_0
+(0 7) routing glb_netwk_1 <X> glb2local_0
 (0 7) routing glb_netwk_3 <X> glb2local_0
 (0 7) routing glb_netwk_5 <X> glb2local_0
+(0 7) routing glb_netwk_7 <X> glb2local_0
 (0 8) routing glb_netwk_3 <X> glb2local_1
+(0 8) routing glb_netwk_6 <X> glb2local_1
+(0 9) routing glb_netwk_1 <X> glb2local_1
 (0 9) routing glb_netwk_3 <X> glb2local_1
+(0 9) routing glb_netwk_5 <X> glb2local_1
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_1 glb2local_2
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_3 glb2local_2
 (1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_4 glb2local_2
 (1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_5 glb2local_2
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_6 glb2local_2
+(1 10) Enable bit of Mux _local_links/global_mux_2 => glb_netwk_7 glb2local_2
 (1 11) routing glb_netwk_4 <X> glb2local_2
 (1 11) routing glb_netwk_5 <X> glb2local_2
+(1 11) routing glb_netwk_6 <X> glb2local_2
+(1 11) routing glb_netwk_7 <X> glb2local_2
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_1 glb2local_3
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_3 glb2local_3
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_4 glb2local_3
 (1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_5 glb2local_3
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_6 glb2local_3
+(1 12) Enable bit of Mux _local_links/global_mux_3 => glb_netwk_7 glb2local_3
+(1 13) routing glb_netwk_4 <X> glb2local_3
 (1 13) routing glb_netwk_5 <X> glb2local_3
+(1 13) routing glb_netwk_6 <X> glb2local_3
+(1 13) routing glb_netwk_7 <X> glb2local_3
 (1 14) Enable bit of Mux _global_links/set_rst_mux => glb_netwk_4 wire_bram/ram/WE
+(1 14) Enable bit of Mux _global_links/set_rst_mux => glb_netwk_6 wire_bram/ram/WE
 (1 14) Enable bit of Mux _global_links/set_rst_mux => lc_trk_g0_4 wire_bram/ram/WE
 (1 14) Enable bit of Mux _global_links/set_rst_mux => lc_trk_g1_5 wire_bram/ram/WE
 (1 14) Enable bit of Mux _global_links/set_rst_mux => lc_trk_g2_4 wire_bram/ram/WE
@@ -40,7 +80,9 @@
 (1 15) routing lc_trk_g1_5 <X> wire_bram/ram/WE
 (1 15) routing lc_trk_g2_4 <X> wire_bram/ram/WE
 (1 15) routing lc_trk_g3_5 <X> wire_bram/ram/WE
+(1 2) routing glb_netwk_4 <X> wire_bram/ram/WCLK
 (1 2) routing glb_netwk_5 <X> wire_bram/ram/WCLK
+(1 2) routing glb_netwk_6 <X> wire_bram/ram/WCLK
 (1 2) routing glb_netwk_7 <X> wire_bram/ram/WCLK
 (1 3) Enable bit of Mux _span_links/cross_mux_horz_5 => sp12_h_r_10 sp4_h_r_17
 (1 4) Enable bit of Mux _global_links/ce_mux => glb_netwk_3 wire_bram/ram/WCLKE
@@ -53,41 +95,65 @@
 (1 5) routing lc_trk_g1_3 <X> wire_bram/ram/WCLKE
 (1 5) routing lc_trk_g2_2 <X> wire_bram/ram/WCLKE
 (1 5) routing lc_trk_g3_3 <X> wire_bram/ram/WCLKE
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_1 glb2local_0
 (1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_3 glb2local_0
 (1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_4 glb2local_0
 (1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_5 glb2local_0
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_6 glb2local_0
+(1 6) Enable bit of Mux _local_links/global_mux_0 => glb_netwk_7 glb2local_0
 (1 7) routing glb_netwk_4 <X> glb2local_0
 (1 7) routing glb_netwk_5 <X> glb2local_0
+(1 7) routing glb_netwk_6 <X> glb2local_0
+(1 7) routing glb_netwk_7 <X> glb2local_0
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_1 glb2local_1
 (1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_3 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_4 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_5 glb2local_1
+(1 8) Enable bit of Mux _local_links/global_mux_1 => glb_netwk_6 glb2local_1
+(1 9) routing glb_netwk_4 <X> glb2local_1
+(1 9) routing glb_netwk_5 <X> glb2local_1
+(1 9) routing glb_netwk_6 <X> glb2local_1
+(10 0) routing sp4_h_l_40 <X> sp4_h_r_1
+(10 0) routing sp4_h_l_47 <X> sp4_h_r_1
+(10 0) routing sp4_v_b_7 <X> sp4_h_r_1
+(10 0) routing sp4_v_t_45 <X> sp4_h_r_1
 (10 1) routing sp4_h_l_42 <X> sp4_v_b_1
 (10 1) routing sp4_h_r_8 <X> sp4_v_b_1
 (10 1) routing sp4_v_t_40 <X> sp4_v_b_1
 (10 1) routing sp4_v_t_47 <X> sp4_v_b_1
 (10 10) routing sp4_h_r_11 <X> sp4_h_l_42
+(10 10) routing sp4_h_r_4 <X> sp4_h_l_42
 (10 10) routing sp4_v_b_2 <X> sp4_h_l_42
 (10 10) routing sp4_v_t_36 <X> sp4_h_l_42
 (10 11) routing sp4_h_l_39 <X> sp4_v_t_42
 (10 11) routing sp4_h_r_1 <X> sp4_v_t_42
 (10 11) routing sp4_v_b_11 <X> sp4_v_t_42
 (10 11) routing sp4_v_b_4 <X> sp4_v_t_42
+(10 12) routing sp4_h_l_39 <X> sp4_h_r_10
+(10 12) routing sp4_h_l_42 <X> sp4_h_r_10
 (10 12) routing sp4_v_b_4 <X> sp4_h_r_10
 (10 12) routing sp4_v_t_40 <X> sp4_h_r_10
 (10 13) routing sp4_h_l_41 <X> sp4_v_b_10
 (10 13) routing sp4_h_r_5 <X> sp4_v_b_10
 (10 13) routing sp4_v_t_39 <X> sp4_v_b_10
 (10 13) routing sp4_v_t_42 <X> sp4_v_b_10
+(10 14) routing sp4_h_r_2 <X> sp4_h_l_47
+(10 14) routing sp4_h_r_7 <X> sp4_h_l_47
 (10 14) routing sp4_v_b_5 <X> sp4_h_l_47
 (10 14) routing sp4_v_t_41 <X> sp4_h_l_47
 (10 15) routing sp4_h_l_40 <X> sp4_v_t_47
+(10 15) routing sp4_h_r_4 <X> sp4_v_t_47
 (10 15) routing sp4_v_b_2 <X> sp4_v_t_47
 (10 15) routing sp4_v_b_7 <X> sp4_v_t_47
 (10 2) routing sp4_h_r_10 <X> sp4_h_l_36
+(10 2) routing sp4_h_r_5 <X> sp4_h_l_36
 (10 2) routing sp4_v_b_8 <X> sp4_h_l_36
 (10 2) routing sp4_v_t_42 <X> sp4_h_l_36
 (10 3) routing sp4_h_l_45 <X> sp4_v_t_36
 (10 3) routing sp4_h_r_7 <X> sp4_v_t_36
 (10 3) routing sp4_v_b_10 <X> sp4_v_t_36
 (10 3) routing sp4_v_b_5 <X> sp4_v_t_36
+(10 4) routing sp4_h_l_36 <X> sp4_h_r_4
 (10 4) routing sp4_h_l_45 <X> sp4_h_r_4
 (10 4) routing sp4_v_b_10 <X> sp4_h_r_4
 (10 4) routing sp4_v_t_46 <X> sp4_h_r_4
@@ -96,12 +162,15 @@
 (10 5) routing sp4_v_t_36 <X> sp4_v_b_4
 (10 5) routing sp4_v_t_45 <X> sp4_v_b_4
 (10 6) routing sp4_h_r_1 <X> sp4_h_l_41
+(10 6) routing sp4_h_r_8 <X> sp4_h_l_41
 (10 6) routing sp4_v_b_11 <X> sp4_h_l_41
 (10 6) routing sp4_v_t_47 <X> sp4_h_l_41
 (10 7) routing sp4_h_l_46 <X> sp4_v_t_41
 (10 7) routing sp4_h_r_10 <X> sp4_v_t_41
 (10 7) routing sp4_v_b_1 <X> sp4_v_t_41
 (10 7) routing sp4_v_b_8 <X> sp4_v_t_41
+(10 8) routing sp4_h_l_41 <X> sp4_h_r_7
+(10 8) routing sp4_h_l_46 <X> sp4_h_r_7
 (10 8) routing sp4_v_b_1 <X> sp4_h_r_7
 (10 8) routing sp4_v_t_39 <X> sp4_h_r_7
 (10 9) routing sp4_h_l_36 <X> sp4_v_b_7
@@ -112,10 +181,15 @@
 (11 0) routing sp4_h_r_9 <X> sp4_v_b_2
 (11 0) routing sp4_v_t_43 <X> sp4_v_b_2
 (11 0) routing sp4_v_t_46 <X> sp4_v_b_2
+(11 1) routing sp4_h_l_43 <X> sp4_h_r_2
+(11 1) routing sp4_v_b_2 <X> sp4_h_r_2
 (11 1) routing sp4_v_b_8 <X> sp4_h_r_2
 (11 10) routing sp4_h_l_38 <X> sp4_v_t_45
+(11 10) routing sp4_h_r_2 <X> sp4_v_t_45
 (11 10) routing sp4_v_b_0 <X> sp4_v_t_45
 (11 10) routing sp4_v_b_5 <X> sp4_v_t_45
+(11 11) routing sp4_h_r_0 <X> sp4_h_l_45
+(11 11) routing sp4_h_r_8 <X> sp4_h_l_45
 (11 11) routing sp4_v_t_39 <X> sp4_h_l_45
 (11 11) routing sp4_v_t_45 <X> sp4_h_l_45
 (11 12) routing sp4_h_l_40 <X> sp4_v_b_11
@@ -123,12 +197,14 @@
 (11 12) routing sp4_v_t_38 <X> sp4_v_b_11
 (11 12) routing sp4_v_t_45 <X> sp4_v_b_11
 (11 13) routing sp4_h_l_38 <X> sp4_h_r_11
+(11 13) routing sp4_h_l_46 <X> sp4_h_r_11
 (11 13) routing sp4_v_b_11 <X> sp4_h_r_11
 (11 13) routing sp4_v_b_5 <X> sp4_h_r_11
 (11 14) routing sp4_h_l_43 <X> sp4_v_t_46
 (11 14) routing sp4_h_r_5 <X> sp4_v_t_46
 (11 14) routing sp4_v_b_3 <X> sp4_v_t_46
 (11 14) routing sp4_v_b_8 <X> sp4_v_t_46
+(11 15) routing sp4_h_r_11 <X> sp4_h_l_46
 (11 15) routing sp4_h_r_3 <X> sp4_h_l_46
 (11 15) routing sp4_v_t_40 <X> sp4_h_l_46
 (11 15) routing sp4_v_t_46 <X> sp4_h_l_46
@@ -137,22 +213,34 @@
 (11 2) routing sp4_v_b_11 <X> sp4_v_t_39
 (11 2) routing sp4_v_b_6 <X> sp4_v_t_39
 (11 3) routing sp4_h_r_2 <X> sp4_h_l_39
+(11 3) routing sp4_h_r_6 <X> sp4_h_l_39
 (11 3) routing sp4_v_t_39 <X> sp4_h_l_39
 (11 3) routing sp4_v_t_45 <X> sp4_h_l_39
 (11 4) routing sp4_h_l_46 <X> sp4_v_b_5
 (11 4) routing sp4_h_r_0 <X> sp4_v_b_5
 (11 4) routing sp4_v_t_39 <X> sp4_v_b_5
 (11 4) routing sp4_v_t_44 <X> sp4_v_b_5
+(11 5) routing sp4_h_l_40 <X> sp4_h_r_5
+(11 5) routing sp4_v_b_11 <X> sp4_h_r_5
 (11 5) routing sp4_v_b_5 <X> sp4_h_r_5
 (11 6) routing sp4_h_l_37 <X> sp4_v_t_40
 (11 6) routing sp4_h_r_11 <X> sp4_v_t_40
 (11 6) routing sp4_v_b_2 <X> sp4_v_t_40
 (11 6) routing sp4_v_b_9 <X> sp4_v_t_40
+(11 7) routing sp4_h_r_5 <X> sp4_h_l_40
+(11 7) routing sp4_h_r_9 <X> sp4_h_l_40
 (11 7) routing sp4_v_t_40 <X> sp4_h_l_40
+(11 7) routing sp4_v_t_46 <X> sp4_h_l_40
 (11 8) routing sp4_h_l_39 <X> sp4_v_b_8
 (11 8) routing sp4_h_r_3 <X> sp4_v_b_8
 (11 8) routing sp4_v_t_37 <X> sp4_v_b_8
 (11 8) routing sp4_v_t_40 <X> sp4_v_b_8
+(11 9) routing sp4_h_l_37 <X> sp4_h_r_8
+(11 9) routing sp4_h_l_45 <X> sp4_h_r_8
+(11 9) routing sp4_v_b_2 <X> sp4_h_r_8
+(11 9) routing sp4_v_b_8 <X> sp4_h_r_8
+(12 0) routing sp4_h_l_46 <X> sp4_h_r_2
+(12 0) routing sp4_v_b_2 <X> sp4_h_r_2
 (12 0) routing sp4_v_b_8 <X> sp4_h_r_2
 (12 0) routing sp4_v_t_39 <X> sp4_h_r_2
 (12 1) routing sp4_h_l_39 <X> sp4_v_b_2
@@ -164,7 +252,10 @@
 (12 10) routing sp4_v_t_39 <X> sp4_h_l_45
 (12 10) routing sp4_v_t_45 <X> sp4_h_l_45
 (12 11) routing sp4_h_l_45 <X> sp4_v_t_45
+(12 11) routing sp4_h_r_2 <X> sp4_v_t_45
+(12 11) routing sp4_h_r_8 <X> sp4_v_t_45
 (12 11) routing sp4_v_b_5 <X> sp4_v_t_45
+(12 12) routing sp4_h_l_45 <X> sp4_h_r_11
 (12 12) routing sp4_v_b_11 <X> sp4_h_r_11
 (12 12) routing sp4_v_b_5 <X> sp4_h_r_11
 (12 12) routing sp4_v_t_46 <X> sp4_h_r_11
@@ -172,6 +263,7 @@
 (12 13) routing sp4_h_l_46 <X> sp4_v_b_11
 (12 13) routing sp4_h_r_11 <X> sp4_v_b_11
 (12 13) routing sp4_v_t_45 <X> sp4_v_b_11
+(12 14) routing sp4_h_r_8 <X> sp4_h_l_46
 (12 14) routing sp4_v_b_11 <X> sp4_h_l_46
 (12 14) routing sp4_v_t_40 <X> sp4_h_l_46
 (12 14) routing sp4_v_t_46 <X> sp4_h_l_46
@@ -179,6 +271,8 @@
 (12 15) routing sp4_h_r_11 <X> sp4_v_t_46
 (12 15) routing sp4_h_r_5 <X> sp4_v_t_46
 (12 15) routing sp4_v_b_8 <X> sp4_v_t_46
+(12 2) routing sp4_h_r_11 <X> sp4_h_l_39
+(12 2) routing sp4_v_b_2 <X> sp4_h_l_39
 (12 2) routing sp4_v_t_39 <X> sp4_h_l_39
 (12 2) routing sp4_v_t_45 <X> sp4_h_l_39
 (12 3) routing sp4_h_l_39 <X> sp4_v_t_39
@@ -186,18 +280,24 @@
 (12 3) routing sp4_h_r_8 <X> sp4_v_t_39
 (12 3) routing sp4_v_b_11 <X> sp4_v_t_39
 (12 4) routing sp4_h_l_39 <X> sp4_h_r_5
+(12 4) routing sp4_v_b_11 <X> sp4_h_r_5
 (12 4) routing sp4_v_b_5 <X> sp4_h_r_5
 (12 4) routing sp4_v_t_40 <X> sp4_h_r_5
 (12 5) routing sp4_h_l_40 <X> sp4_v_b_5
 (12 5) routing sp4_h_l_46 <X> sp4_v_b_5
 (12 5) routing sp4_h_r_5 <X> sp4_v_b_5
 (12 5) routing sp4_v_t_39 <X> sp4_v_b_5
+(12 6) routing sp4_h_r_2 <X> sp4_h_l_40
 (12 6) routing sp4_v_b_5 <X> sp4_h_l_40
 (12 6) routing sp4_v_t_40 <X> sp4_h_l_40
+(12 6) routing sp4_v_t_46 <X> sp4_h_l_40
 (12 7) routing sp4_h_l_40 <X> sp4_v_t_40
 (12 7) routing sp4_h_r_11 <X> sp4_v_t_40
 (12 7) routing sp4_h_r_5 <X> sp4_v_t_40
 (12 7) routing sp4_v_b_2 <X> sp4_v_t_40
+(12 8) routing sp4_h_l_40 <X> sp4_h_r_8
+(12 8) routing sp4_v_b_2 <X> sp4_h_r_8
+(12 8) routing sp4_v_b_8 <X> sp4_h_r_8
 (12 8) routing sp4_v_t_45 <X> sp4_h_r_8
 (12 9) routing sp4_h_l_39 <X> sp4_v_b_8
 (12 9) routing sp4_h_l_45 <X> sp4_v_b_8
@@ -207,17 +307,24 @@
 (13 0) routing sp4_h_l_45 <X> sp4_v_b_2
 (13 0) routing sp4_v_t_39 <X> sp4_v_b_2
 (13 0) routing sp4_v_t_43 <X> sp4_v_b_2
+(13 1) routing sp4_h_l_43 <X> sp4_h_r_2
+(13 1) routing sp4_h_l_46 <X> sp4_h_r_2
 (13 1) routing sp4_v_b_8 <X> sp4_h_r_2
 (13 1) routing sp4_v_t_44 <X> sp4_h_r_2
+(13 10) routing sp4_h_r_2 <X> sp4_v_t_45
+(13 10) routing sp4_h_r_8 <X> sp4_v_t_45
 (13 10) routing sp4_v_b_0 <X> sp4_v_t_45
 (13 10) routing sp4_v_b_8 <X> sp4_v_t_45
+(13 11) routing sp4_h_r_0 <X> sp4_h_l_45
 (13 11) routing sp4_h_r_5 <X> sp4_h_l_45
+(13 11) routing sp4_v_b_3 <X> sp4_h_l_45
 (13 11) routing sp4_v_t_39 <X> sp4_h_l_45
 (13 12) routing sp4_h_l_40 <X> sp4_v_b_11
 (13 12) routing sp4_h_l_46 <X> sp4_v_b_11
 (13 12) routing sp4_v_t_38 <X> sp4_v_b_11
 (13 12) routing sp4_v_t_46 <X> sp4_v_b_11
 (13 13) routing sp4_h_l_38 <X> sp4_h_r_11
+(13 13) routing sp4_h_l_45 <X> sp4_h_r_11
 (13 13) routing sp4_v_b_5 <X> sp4_h_r_11
 (13 13) routing sp4_v_t_43 <X> sp4_h_r_11
 (13 14) routing sp4_h_r_11 <X> sp4_v_t_46
@@ -225,12 +332,15 @@
 (13 14) routing sp4_v_b_11 <X> sp4_v_t_46
 (13 14) routing sp4_v_b_3 <X> sp4_v_t_46
 (13 15) routing sp4_h_r_3 <X> sp4_h_l_46
+(13 15) routing sp4_h_r_8 <X> sp4_h_l_46
 (13 15) routing sp4_v_b_6 <X> sp4_h_l_46
 (13 15) routing sp4_v_t_40 <X> sp4_h_l_46
 (13 2) routing sp4_h_r_2 <X> sp4_v_t_39
 (13 2) routing sp4_h_r_8 <X> sp4_v_t_39
 (13 2) routing sp4_v_b_2 <X> sp4_v_t_39
 (13 2) routing sp4_v_b_6 <X> sp4_v_t_39
+(13 3) routing sp4_h_r_11 <X> sp4_h_l_39
+(13 3) routing sp4_h_r_6 <X> sp4_h_l_39
 (13 3) routing sp4_v_b_9 <X> sp4_h_l_39
 (13 3) routing sp4_v_t_45 <X> sp4_h_l_39
 (13 4) routing sp4_h_l_40 <X> sp4_v_b_5
@@ -238,35 +348,48 @@
 (13 4) routing sp4_v_t_40 <X> sp4_v_b_5
 (13 4) routing sp4_v_t_44 <X> sp4_v_b_5
 (13 5) routing sp4_h_l_39 <X> sp4_h_r_5
+(13 5) routing sp4_v_b_11 <X> sp4_h_r_5
+(13 5) routing sp4_v_t_37 <X> sp4_h_r_5
 (13 6) routing sp4_h_r_11 <X> sp4_v_t_40
 (13 6) routing sp4_h_r_5 <X> sp4_v_t_40
 (13 6) routing sp4_v_b_5 <X> sp4_v_t_40
 (13 6) routing sp4_v_b_9 <X> sp4_v_t_40
+(13 7) routing sp4_h_r_2 <X> sp4_h_l_40
+(13 7) routing sp4_h_r_9 <X> sp4_h_l_40
 (13 7) routing sp4_v_b_0 <X> sp4_h_l_40
+(13 7) routing sp4_v_t_46 <X> sp4_h_l_40
 (13 8) routing sp4_h_l_39 <X> sp4_v_b_8
 (13 8) routing sp4_h_l_45 <X> sp4_v_b_8
 (13 8) routing sp4_v_t_37 <X> sp4_v_b_8
 (13 8) routing sp4_v_t_45 <X> sp4_v_b_8
+(13 9) routing sp4_h_l_37 <X> sp4_h_r_8
+(13 9) routing sp4_h_l_40 <X> sp4_h_r_8
+(13 9) routing sp4_v_b_2 <X> sp4_h_r_8
 (13 9) routing sp4_v_t_38 <X> sp4_h_r_8
 (14 0) routing bnr_op_0 <X> lc_trk_g0_0
 (14 0) routing lft_op_0 <X> lc_trk_g0_0
+(14 0) routing sp12_h_r_0 <X> lc_trk_g0_0
 (14 0) routing sp4_h_l_5 <X> lc_trk_g0_0
 (14 0) routing sp4_h_r_8 <X> lc_trk_g0_0
 (14 0) routing sp4_v_b_0 <X> lc_trk_g0_0
 (14 0) routing sp4_v_b_8 <X> lc_trk_g0_0
 (14 1) routing bnr_op_0 <X> lc_trk_g0_0
+(14 1) routing sp12_h_r_0 <X> lc_trk_g0_0
+(14 1) routing sp12_h_r_16 <X> lc_trk_g0_0
 (14 1) routing sp4_h_l_5 <X> lc_trk_g0_0
 (14 1) routing sp4_h_r_0 <X> lc_trk_g0_0
 (14 1) routing sp4_r_v_b_35 <X> lc_trk_g0_0
 (14 1) routing sp4_v_b_8 <X> lc_trk_g0_0
 (14 10) routing bnl_op_4 <X> lc_trk_g2_4
 (14 10) routing rgt_op_4 <X> lc_trk_g2_4
+(14 10) routing sp12_v_t_3 <X> lc_trk_g2_4
 (14 10) routing sp4_h_r_36 <X> lc_trk_g2_4
 (14 10) routing sp4_h_r_44 <X> lc_trk_g2_4
 (14 10) routing sp4_v_b_28 <X> lc_trk_g2_4
 (14 10) routing sp4_v_t_25 <X> lc_trk_g2_4
 (14 11) routing bnl_op_4 <X> lc_trk_g2_4
 (14 11) routing sp12_v_t_19 <X> lc_trk_g2_4
+(14 11) routing sp12_v_t_3 <X> lc_trk_g2_4
 (14 11) routing sp4_h_l_17 <X> lc_trk_g2_4
 (14 11) routing sp4_h_r_44 <X> lc_trk_g2_4
 (14 11) routing sp4_r_v_b_36 <X> lc_trk_g2_4
@@ -275,12 +398,14 @@
 (14 12) routing bnl_op_0 <X> lc_trk_g3_0
 (14 12) routing rgt_op_0 <X> lc_trk_g3_0
 (14 12) routing sp12_v_b_0 <X> lc_trk_g3_0
+(14 12) routing sp4_h_l_21 <X> lc_trk_g3_0
 (14 12) routing sp4_h_l_29 <X> lc_trk_g3_0
 (14 12) routing sp4_v_t_13 <X> lc_trk_g3_0
 (14 12) routing sp4_v_t_21 <X> lc_trk_g3_0
 (14 13) routing bnl_op_0 <X> lc_trk_g3_0
 (14 13) routing sp12_v_b_0 <X> lc_trk_g3_0
 (14 13) routing sp12_v_b_16 <X> lc_trk_g3_0
+(14 13) routing sp4_h_l_13 <X> lc_trk_g3_0
 (14 13) routing sp4_h_l_29 <X> lc_trk_g3_0
 (14 13) routing sp4_r_v_b_40 <X> lc_trk_g3_0
 (14 13) routing sp4_v_t_21 <X> lc_trk_g3_0
@@ -295,6 +420,7 @@
 (14 15) routing bnl_op_4 <X> lc_trk_g3_4
 (14 15) routing sp12_v_t_19 <X> lc_trk_g3_4
 (14 15) routing sp12_v_t_3 <X> lc_trk_g3_4
+(14 15) routing sp4_h_l_17 <X> lc_trk_g3_4
 (14 15) routing sp4_h_r_44 <X> lc_trk_g3_4
 (14 15) routing sp4_r_v_b_44 <X> lc_trk_g3_4
 (14 15) routing sp4_v_t_25 <X> lc_trk_g3_4
@@ -308,6 +434,7 @@
 (14 2) routing sp4_v_t_1 <X> lc_trk_g0_4
 (14 3) routing bnr_op_4 <X> lc_trk_g0_4
 (14 3) routing sp12_h_l_3 <X> lc_trk_g0_4
+(14 3) routing sp12_h_r_20 <X> lc_trk_g0_4
 (14 3) routing sp4_h_r_20 <X> lc_trk_g0_4
 (14 3) routing sp4_h_r_4 <X> lc_trk_g0_4
 (14 3) routing sp4_r_v_b_28 <X> lc_trk_g0_4
@@ -329,16 +456,20 @@
 (14 5) routing sp4_v_b_8 <X> lc_trk_g1_0
 (14 6) routing bnr_op_4 <X> lc_trk_g1_4
 (14 6) routing lft_op_4 <X> lc_trk_g1_4
+(14 6) routing sp12_h_l_3 <X> lc_trk_g1_4
 (14 6) routing sp4_h_r_12 <X> lc_trk_g1_4
 (14 6) routing sp4_h_r_20 <X> lc_trk_g1_4
 (14 6) routing sp4_v_b_4 <X> lc_trk_g1_4
 (14 6) routing sp4_v_t_1 <X> lc_trk_g1_4
 (14 7) routing bnr_op_4 <X> lc_trk_g1_4
+(14 7) routing sp12_h_l_3 <X> lc_trk_g1_4
+(14 7) routing sp12_h_r_20 <X> lc_trk_g1_4
 (14 7) routing sp4_h_r_20 <X> lc_trk_g1_4
 (14 7) routing sp4_h_r_4 <X> lc_trk_g1_4
 (14 7) routing sp4_r_v_b_28 <X> lc_trk_g1_4
 (14 7) routing sp4_v_t_1 <X> lc_trk_g1_4
 (14 8) routing bnl_op_0 <X> lc_trk_g2_0
+(14 8) routing rgt_op_0 <X> lc_trk_g2_0
 (14 8) routing sp12_v_b_0 <X> lc_trk_g2_0
 (14 8) routing sp4_h_l_21 <X> lc_trk_g2_0
 (14 8) routing sp4_h_l_29 <X> lc_trk_g2_0
@@ -359,31 +490,39 @@
 (15 0) routing sp4_h_r_9 <X> lc_trk_g0_1
 (15 0) routing sp4_v_b_17 <X> lc_trk_g0_1
 (15 1) routing lft_op_0 <X> lc_trk_g0_0
+(15 1) routing sp12_h_r_0 <X> lc_trk_g0_0
 (15 1) routing sp4_h_l_5 <X> lc_trk_g0_0
 (15 1) routing sp4_h_r_0 <X> lc_trk_g0_0
 (15 1) routing sp4_h_r_8 <X> lc_trk_g0_0
 (15 1) routing sp4_v_b_16 <X> lc_trk_g0_0
+(15 10) routing rgt_op_5 <X> lc_trk_g2_5
 (15 10) routing sp12_v_b_5 <X> lc_trk_g2_5
 (15 10) routing sp4_h_l_16 <X> lc_trk_g2_5
+(15 10) routing sp4_h_r_37 <X> lc_trk_g2_5
 (15 10) routing sp4_h_r_45 <X> lc_trk_g2_5
 (15 10) routing sp4_v_b_45 <X> lc_trk_g2_5
 (15 10) routing tnl_op_5 <X> lc_trk_g2_5
 (15 10) routing tnr_op_5 <X> lc_trk_g2_5
 (15 11) routing rgt_op_4 <X> lc_trk_g2_4
+(15 11) routing sp12_v_t_3 <X> lc_trk_g2_4
 (15 11) routing sp4_h_l_17 <X> lc_trk_g2_4
 (15 11) routing sp4_h_r_36 <X> lc_trk_g2_4
 (15 11) routing sp4_h_r_44 <X> lc_trk_g2_4
 (15 11) routing sp4_v_t_33 <X> lc_trk_g2_4
 (15 11) routing tnl_op_4 <X> lc_trk_g2_4
 (15 11) routing tnr_op_4 <X> lc_trk_g2_4
+(15 12) routing rgt_op_1 <X> lc_trk_g3_1
 (15 12) routing sp12_v_b_1 <X> lc_trk_g3_1
 (15 12) routing sp4_h_l_20 <X> lc_trk_g3_1
 (15 12) routing sp4_h_l_28 <X> lc_trk_g3_1
 (15 12) routing sp4_h_r_25 <X> lc_trk_g3_1
 (15 12) routing sp4_v_b_41 <X> lc_trk_g3_1
 (15 12) routing tnl_op_1 <X> lc_trk_g3_1
+(15 12) routing tnr_op_1 <X> lc_trk_g3_1
 (15 13) routing rgt_op_0 <X> lc_trk_g3_0
 (15 13) routing sp12_v_b_0 <X> lc_trk_g3_0
+(15 13) routing sp4_h_l_13 <X> lc_trk_g3_0
+(15 13) routing sp4_h_l_21 <X> lc_trk_g3_0
 (15 13) routing sp4_h_l_29 <X> lc_trk_g3_0
 (15 13) routing sp4_v_b_40 <X> lc_trk_g3_0
 (15 13) routing tnl_op_0 <X> lc_trk_g3_0
@@ -395,16 +534,20 @@
 (15 14) routing sp4_h_r_45 <X> lc_trk_g3_5
 (15 14) routing sp4_v_b_45 <X> lc_trk_g3_5
 (15 14) routing tnl_op_5 <X> lc_trk_g3_5
+(15 14) routing tnr_op_5 <X> lc_trk_g3_5
 (15 15) routing rgt_op_4 <X> lc_trk_g3_4
 (15 15) routing sp12_v_t_3 <X> lc_trk_g3_4
+(15 15) routing sp4_h_l_17 <X> lc_trk_g3_4
 (15 15) routing sp4_h_r_36 <X> lc_trk_g3_4
 (15 15) routing sp4_h_r_44 <X> lc_trk_g3_4
 (15 15) routing sp4_v_t_33 <X> lc_trk_g3_4
 (15 15) routing tnl_op_4 <X> lc_trk_g3_4
+(15 15) routing tnr_op_4 <X> lc_trk_g3_4
 (15 2) routing lft_op_5 <X> lc_trk_g0_5
 (15 2) routing sp12_h_r_5 <X> lc_trk_g0_5
 (15 2) routing sp4_h_l_8 <X> lc_trk_g0_5
 (15 2) routing sp4_h_r_13 <X> lc_trk_g0_5
+(15 2) routing sp4_h_r_5 <X> lc_trk_g0_5
 (15 2) routing sp4_v_t_8 <X> lc_trk_g0_5
 (15 3) routing lft_op_4 <X> lc_trk_g0_4
 (15 3) routing sp12_h_l_3 <X> lc_trk_g0_4
@@ -426,15 +569,18 @@
 (15 5) routing sp4_h_r_8 <X> lc_trk_g1_0
 (15 5) routing sp4_v_b_16 <X> lc_trk_g1_0
 (15 6) routing lft_op_5 <X> lc_trk_g1_5
+(15 6) routing sp12_h_r_5 <X> lc_trk_g1_5
 (15 6) routing sp4_h_l_8 <X> lc_trk_g1_5
 (15 6) routing sp4_h_r_13 <X> lc_trk_g1_5
 (15 6) routing sp4_h_r_5 <X> lc_trk_g1_5
 (15 6) routing sp4_v_t_8 <X> lc_trk_g1_5
 (15 7) routing lft_op_4 <X> lc_trk_g1_4
+(15 7) routing sp12_h_l_3 <X> lc_trk_g1_4
 (15 7) routing sp4_h_r_12 <X> lc_trk_g1_4
 (15 7) routing sp4_h_r_20 <X> lc_trk_g1_4
 (15 7) routing sp4_h_r_4 <X> lc_trk_g1_4
 (15 7) routing sp4_v_b_20 <X> lc_trk_g1_4
+(15 8) routing rgt_op_1 <X> lc_trk_g2_1
 (15 8) routing sp12_v_b_1 <X> lc_trk_g2_1
 (15 8) routing sp4_h_l_20 <X> lc_trk_g2_1
 (15 8) routing sp4_h_l_28 <X> lc_trk_g2_1
@@ -442,6 +588,7 @@
 (15 8) routing sp4_v_b_41 <X> lc_trk_g2_1
 (15 8) routing tnl_op_1 <X> lc_trk_g2_1
 (15 8) routing tnr_op_1 <X> lc_trk_g2_1
+(15 9) routing rgt_op_0 <X> lc_trk_g2_0
 (15 9) routing sp12_v_b_0 <X> lc_trk_g2_0
 (15 9) routing sp4_h_l_13 <X> lc_trk_g2_0
 (15 9) routing sp4_h_l_21 <X> lc_trk_g2_0
@@ -449,12 +596,15 @@
 (15 9) routing sp4_v_b_40 <X> lc_trk_g2_0
 (15 9) routing tnl_op_0 <X> lc_trk_g2_0
 (15 9) routing tnr_op_0 <X> lc_trk_g2_0
+(16 0) routing sp12_h_l_6 <X> lc_trk_g0_1
+(16 0) routing sp12_h_r_17 <X> lc_trk_g0_1
 (16 0) routing sp4_h_r_1 <X> lc_trk_g0_1
 (16 0) routing sp4_h_r_17 <X> lc_trk_g0_1
 (16 0) routing sp4_h_r_9 <X> lc_trk_g0_1
 (16 0) routing sp4_v_b_1 <X> lc_trk_g0_1
 (16 0) routing sp4_v_b_17 <X> lc_trk_g0_1
 (16 0) routing sp4_v_b_9 <X> lc_trk_g0_1
+(16 1) routing sp12_h_r_16 <X> lc_trk_g0_0
 (16 1) routing sp12_h_r_8 <X> lc_trk_g0_0
 (16 1) routing sp4_h_l_5 <X> lc_trk_g0_0
 (16 1) routing sp4_h_r_0 <X> lc_trk_g0_0
@@ -465,6 +615,7 @@
 (16 10) routing sp12_v_b_21 <X> lc_trk_g2_5
 (16 10) routing sp12_v_t_10 <X> lc_trk_g2_5
 (16 10) routing sp4_h_l_16 <X> lc_trk_g2_5
+(16 10) routing sp4_h_r_37 <X> lc_trk_g2_5
 (16 10) routing sp4_h_r_45 <X> lc_trk_g2_5
 (16 10) routing sp4_v_b_29 <X> lc_trk_g2_5
 (16 10) routing sp4_v_b_37 <X> lc_trk_g2_5
@@ -487,6 +638,8 @@
 (16 12) routing sp4_v_b_41 <X> lc_trk_g3_1
 (16 13) routing sp12_v_b_16 <X> lc_trk_g3_0
 (16 13) routing sp12_v_t_7 <X> lc_trk_g3_0
+(16 13) routing sp4_h_l_13 <X> lc_trk_g3_0
+(16 13) routing sp4_h_l_21 <X> lc_trk_g3_0
 (16 13) routing sp4_h_l_29 <X> lc_trk_g3_0
 (16 13) routing sp4_v_b_40 <X> lc_trk_g3_0
 (16 13) routing sp4_v_t_13 <X> lc_trk_g3_0
@@ -501,17 +654,22 @@
 (16 14) routing sp4_v_b_45 <X> lc_trk_g3_5
 (16 15) routing sp12_v_b_12 <X> lc_trk_g3_4
 (16 15) routing sp12_v_t_19 <X> lc_trk_g3_4
+(16 15) routing sp4_h_l_17 <X> lc_trk_g3_4
 (16 15) routing sp4_h_r_36 <X> lc_trk_g3_4
 (16 15) routing sp4_h_r_44 <X> lc_trk_g3_4
 (16 15) routing sp4_v_b_28 <X> lc_trk_g3_4
 (16 15) routing sp4_v_t_25 <X> lc_trk_g3_4
 (16 15) routing sp4_v_t_33 <X> lc_trk_g3_4
+(16 2) routing sp12_h_l_18 <X> lc_trk_g0_5
 (16 2) routing sp12_h_r_13 <X> lc_trk_g0_5
 (16 2) routing sp4_h_l_8 <X> lc_trk_g0_5
 (16 2) routing sp4_h_r_13 <X> lc_trk_g0_5
+(16 2) routing sp4_h_r_5 <X> lc_trk_g0_5
 (16 2) routing sp4_v_b_13 <X> lc_trk_g0_5
 (16 2) routing sp4_v_b_5 <X> lc_trk_g0_5
 (16 2) routing sp4_v_t_8 <X> lc_trk_g0_5
+(16 3) routing sp12_h_r_12 <X> lc_trk_g0_4
+(16 3) routing sp12_h_r_20 <X> lc_trk_g0_4
 (16 3) routing sp4_h_r_12 <X> lc_trk_g0_4
 (16 3) routing sp4_h_r_20 <X> lc_trk_g0_4
 (16 3) routing sp4_h_r_4 <X> lc_trk_g0_4
@@ -519,6 +677,7 @@
 (16 3) routing sp4_v_b_4 <X> lc_trk_g0_4
 (16 3) routing sp4_v_t_1 <X> lc_trk_g0_4
 (16 4) routing sp12_h_l_6 <X> lc_trk_g1_1
+(16 4) routing sp12_h_r_17 <X> lc_trk_g1_1
 (16 4) routing sp4_h_r_1 <X> lc_trk_g1_1
 (16 4) routing sp4_h_r_17 <X> lc_trk_g1_1
 (16 4) routing sp4_h_r_9 <X> lc_trk_g1_1
@@ -533,6 +692,7 @@
 (16 5) routing sp4_v_b_0 <X> lc_trk_g1_0
 (16 5) routing sp4_v_b_16 <X> lc_trk_g1_0
 (16 5) routing sp4_v_b_8 <X> lc_trk_g1_0
+(16 6) routing sp12_h_l_18 <X> lc_trk_g1_5
 (16 6) routing sp12_h_r_13 <X> lc_trk_g1_5
 (16 6) routing sp4_h_l_8 <X> lc_trk_g1_5
 (16 6) routing sp4_h_r_13 <X> lc_trk_g1_5
@@ -541,6 +701,7 @@
 (16 6) routing sp4_v_b_5 <X> lc_trk_g1_5
 (16 6) routing sp4_v_t_8 <X> lc_trk_g1_5
 (16 7) routing sp12_h_r_12 <X> lc_trk_g1_4
+(16 7) routing sp12_h_r_20 <X> lc_trk_g1_4
 (16 7) routing sp4_h_r_12 <X> lc_trk_g1_4
 (16 7) routing sp4_h_r_20 <X> lc_trk_g1_4
 (16 7) routing sp4_h_r_4 <X> lc_trk_g1_4
@@ -565,7 +726,9 @@
 (16 9) routing sp4_v_t_21 <X> lc_trk_g2_0
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => bnr_op_1 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => lft_op_1 lc_trk_g0_1
+(17 0) Enable bit of Mux _local_links/g0_mux_1 => sp12_h_l_6 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp12_h_r_1 lc_trk_g0_1
+(17 0) Enable bit of Mux _local_links/g0_mux_1 => sp12_h_r_17 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_h_r_1 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_h_r_17 lc_trk_g0_1
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_h_r_9 lc_trk_g0_1
@@ -576,6 +739,8 @@
 (17 0) Enable bit of Mux _local_links/g0_mux_1 => sp4_v_b_9 lc_trk_g0_1
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => bnr_op_0 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => lft_op_0 lc_trk_g0_0
+(17 1) Enable bit of Mux _local_links/g0_mux_0 => sp12_h_r_0 lc_trk_g0_0
+(17 1) Enable bit of Mux _local_links/g0_mux_0 => sp12_h_r_16 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp12_h_r_8 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp4_h_l_5 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp4_h_r_0 lc_trk_g0_0
@@ -586,10 +751,12 @@
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp4_v_b_16 lc_trk_g0_0
 (17 1) Enable bit of Mux _local_links/g0_mux_0 => sp4_v_b_8 lc_trk_g0_0
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => bnl_op_5 lc_trk_g2_5
+(17 10) Enable bit of Mux _local_links/g2_mux_5 => rgt_op_5 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp12_v_b_21 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp12_v_b_5 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp12_v_t_10 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_h_l_16 lc_trk_g2_5
+(17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_h_r_37 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_h_r_45 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_r_v_b_13 lc_trk_g2_5
 (17 10) Enable bit of Mux _local_links/g2_mux_5 => sp4_r_v_b_37 lc_trk_g2_5
@@ -602,6 +769,7 @@
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => rgt_op_4 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp12_v_b_12 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp12_v_t_19 lc_trk_g2_4
+(17 11) Enable bit of Mux _local_links/g2_mux_4 => sp12_v_t_3 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp4_h_l_17 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp4_h_r_36 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => sp4_h_r_44 lc_trk_g2_4
@@ -613,6 +781,7 @@
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => tnl_op_4 lc_trk_g2_4
 (17 11) Enable bit of Mux _local_links/g2_mux_4 => tnr_op_4 lc_trk_g2_4
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => bnl_op_1 lc_trk_g3_1
+(17 12) Enable bit of Mux _local_links/g3_mux_1 => rgt_op_1 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp12_v_b_1 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp12_v_b_17 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp12_v_b_9 lc_trk_g3_1
@@ -625,11 +794,14 @@
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp4_v_b_33 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => sp4_v_b_41 lc_trk_g3_1
 (17 12) Enable bit of Mux _local_links/g3_mux_1 => tnl_op_1 lc_trk_g3_1
+(17 12) Enable bit of Mux _local_links/g3_mux_1 => tnr_op_1 lc_trk_g3_1
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => bnl_op_0 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => rgt_op_0 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp12_v_b_0 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp12_v_b_16 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp12_v_t_7 lc_trk_g3_0
+(17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_h_l_13 lc_trk_g3_0
+(17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_h_l_21 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_h_l_29 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_r_v_b_16 lc_trk_g3_0
 (17 13) Enable bit of Mux _local_links/g3_mux_0 => sp4_r_v_b_40 lc_trk_g3_0
@@ -652,11 +824,13 @@
 (17 14) Enable bit of Mux _local_links/g3_mux_5 => sp4_v_b_37 lc_trk_g3_5
 (17 14) Enable bit of Mux _local_links/g3_mux_5 => sp4_v_b_45 lc_trk_g3_5
 (17 14) Enable bit of Mux _local_links/g3_mux_5 => tnl_op_5 lc_trk_g3_5
+(17 14) Enable bit of Mux _local_links/g3_mux_5 => tnr_op_5 lc_trk_g3_5
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => bnl_op_4 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => rgt_op_4 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp12_v_b_12 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp12_v_t_19 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp12_v_t_3 lc_trk_g3_4
+(17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_h_l_17 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_h_r_36 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_h_r_44 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_r_v_b_20 lc_trk_g3_4
@@ -665,13 +839,16 @@
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_v_t_25 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => sp4_v_t_33 lc_trk_g3_4
 (17 15) Enable bit of Mux _local_links/g3_mux_4 => tnl_op_4 lc_trk_g3_4
+(17 15) Enable bit of Mux _local_links/g3_mux_4 => tnr_op_4 lc_trk_g3_4
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => bnr_op_5 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => glb2local_1 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => lft_op_5 lc_trk_g0_5
+(17 2) Enable bit of Mux _local_links/g0_mux_5 => sp12_h_l_18 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp12_h_r_13 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp12_h_r_5 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_h_l_8 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_h_r_13 lc_trk_g0_5
+(17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_h_r_5 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_r_v_b_29 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_v_b_13 lc_trk_g0_5
 (17 2) Enable bit of Mux _local_links/g0_mux_5 => sp4_v_b_5 lc_trk_g0_5
@@ -680,6 +857,8 @@
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => glb2local_0 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => lft_op_4 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => sp12_h_l_3 lc_trk_g0_4
+(17 3) Enable bit of Mux _local_links/g0_mux_4 => sp12_h_r_12 lc_trk_g0_4
+(17 3) Enable bit of Mux _local_links/g0_mux_4 => sp12_h_r_20 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => sp4_h_r_12 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => sp4_h_r_20 lc_trk_g0_4
 (17 3) Enable bit of Mux _local_links/g0_mux_4 => sp4_h_r_4 lc_trk_g0_4
@@ -692,6 +871,7 @@
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => lft_op_1 lc_trk_g1_1
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp12_h_l_6 lc_trk_g1_1
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp12_h_r_1 lc_trk_g1_1
+(17 4) Enable bit of Mux _local_links/g1_mux_1 => sp12_h_r_17 lc_trk_g1_1
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp4_h_r_1 lc_trk_g1_1
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp4_h_r_17 lc_trk_g1_1
 (17 4) Enable bit of Mux _local_links/g1_mux_1 => sp4_h_r_9 lc_trk_g1_1
@@ -713,8 +893,11 @@
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_v_b_0 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_v_b_16 lc_trk_g1_0
 (17 5) Enable bit of Mux _local_links/g1_mux_0 => sp4_v_b_8 lc_trk_g1_0
+(17 6) Enable bit of Mux _local_links/g1_mux_5 => bnr_op_5 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => lft_op_5 lc_trk_g1_5
+(17 6) Enable bit of Mux _local_links/g1_mux_5 => sp12_h_l_18 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp12_h_r_13 lc_trk_g1_5
+(17 6) Enable bit of Mux _local_links/g1_mux_5 => sp12_h_r_5 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_h_l_8 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_h_r_13 lc_trk_g1_5
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_h_r_5 lc_trk_g1_5
@@ -725,7 +908,9 @@
 (17 6) Enable bit of Mux _local_links/g1_mux_5 => sp4_v_t_8 lc_trk_g1_5
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => bnr_op_4 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => lft_op_4 lc_trk_g1_4
+(17 7) Enable bit of Mux _local_links/g1_mux_4 => sp12_h_l_3 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp12_h_r_12 lc_trk_g1_4
+(17 7) Enable bit of Mux _local_links/g1_mux_4 => sp12_h_r_20 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_h_r_12 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_h_r_20 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_h_r_4 lc_trk_g1_4
@@ -735,6 +920,7 @@
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_v_b_4 lc_trk_g1_4
 (17 7) Enable bit of Mux _local_links/g1_mux_4 => sp4_v_t_1 lc_trk_g1_4
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => bnl_op_1 lc_trk_g2_1
+(17 8) Enable bit of Mux _local_links/g2_mux_1 => rgt_op_1 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp12_v_b_1 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp12_v_b_17 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => sp12_v_b_9 lc_trk_g2_1
@@ -749,6 +935,7 @@
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => tnl_op_1 lc_trk_g2_1
 (17 8) Enable bit of Mux _local_links/g2_mux_1 => tnr_op_1 lc_trk_g2_1
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => bnl_op_0 lc_trk_g2_0
+(17 9) Enable bit of Mux _local_links/g2_mux_0 => rgt_op_0 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => sp12_v_b_0 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => sp12_v_b_16 lc_trk_g2_0
 (17 9) Enable bit of Mux _local_links/g2_mux_0 => sp12_v_t_7 lc_trk_g2_0
@@ -771,12 +958,15 @@
 (18 0) routing sp4_v_b_9 <X> lc_trk_g0_1
 (18 1) routing bnr_op_1 <X> lc_trk_g0_1
 (18 1) routing sp12_h_r_1 <X> lc_trk_g0_1
+(18 1) routing sp12_h_r_17 <X> lc_trk_g0_1
 (18 1) routing sp4_h_r_1 <X> lc_trk_g0_1
 (18 1) routing sp4_h_r_17 <X> lc_trk_g0_1
 (18 1) routing sp4_r_v_b_34 <X> lc_trk_g0_1
 (18 1) routing sp4_v_b_9 <X> lc_trk_g0_1
 (18 10) routing bnl_op_5 <X> lc_trk_g2_5
+(18 10) routing rgt_op_5 <X> lc_trk_g2_5
 (18 10) routing sp12_v_b_5 <X> lc_trk_g2_5
+(18 10) routing sp4_h_r_37 <X> lc_trk_g2_5
 (18 10) routing sp4_h_r_45 <X> lc_trk_g2_5
 (18 10) routing sp4_v_b_29 <X> lc_trk_g2_5
 (18 10) routing sp4_v_b_37 <X> lc_trk_g2_5
@@ -789,6 +979,7 @@
 (18 11) routing sp4_v_b_37 <X> lc_trk_g2_5
 (18 11) routing tnl_op_5 <X> lc_trk_g2_5
 (18 12) routing bnl_op_1 <X> lc_trk_g3_1
+(18 12) routing rgt_op_1 <X> lc_trk_g3_1
 (18 12) routing sp12_v_b_1 <X> lc_trk_g3_1
 (18 12) routing sp4_h_l_20 <X> lc_trk_g3_1
 (18 12) routing sp4_h_l_28 <X> lc_trk_g3_1
@@ -825,8 +1016,10 @@
 (18 2) routing sp4_v_b_13 <X> lc_trk_g0_5
 (18 2) routing sp4_v_b_5 <X> lc_trk_g0_5
 (18 3) routing bnr_op_5 <X> lc_trk_g0_5
+(18 3) routing sp12_h_l_18 <X> lc_trk_g0_5
 (18 3) routing sp12_h_r_5 <X> lc_trk_g0_5
 (18 3) routing sp4_h_l_8 <X> lc_trk_g0_5
+(18 3) routing sp4_h_r_5 <X> lc_trk_g0_5
 (18 3) routing sp4_r_v_b_29 <X> lc_trk_g0_5
 (18 3) routing sp4_v_b_13 <X> lc_trk_g0_5
 (18 4) routing bnr_op_1 <X> lc_trk_g1_1
@@ -838,20 +1031,27 @@
 (18 4) routing sp4_v_b_9 <X> lc_trk_g1_1
 (18 5) routing bnr_op_1 <X> lc_trk_g1_1
 (18 5) routing sp12_h_r_1 <X> lc_trk_g1_1
+(18 5) routing sp12_h_r_17 <X> lc_trk_g1_1
 (18 5) routing sp4_h_r_1 <X> lc_trk_g1_1
 (18 5) routing sp4_h_r_17 <X> lc_trk_g1_1
 (18 5) routing sp4_r_v_b_25 <X> lc_trk_g1_1
 (18 5) routing sp4_v_b_9 <X> lc_trk_g1_1
+(18 6) routing bnr_op_5 <X> lc_trk_g1_5
 (18 6) routing lft_op_5 <X> lc_trk_g1_5
+(18 6) routing sp12_h_r_5 <X> lc_trk_g1_5
 (18 6) routing sp4_h_l_8 <X> lc_trk_g1_5
 (18 6) routing sp4_h_r_13 <X> lc_trk_g1_5
 (18 6) routing sp4_v_b_13 <X> lc_trk_g1_5
 (18 6) routing sp4_v_b_5 <X> lc_trk_g1_5
+(18 7) routing bnr_op_5 <X> lc_trk_g1_5
+(18 7) routing sp12_h_l_18 <X> lc_trk_g1_5
+(18 7) routing sp12_h_r_5 <X> lc_trk_g1_5
 (18 7) routing sp4_h_l_8 <X> lc_trk_g1_5
 (18 7) routing sp4_h_r_5 <X> lc_trk_g1_5
 (18 7) routing sp4_r_v_b_29 <X> lc_trk_g1_5
 (18 7) routing sp4_v_b_13 <X> lc_trk_g1_5
 (18 8) routing bnl_op_1 <X> lc_trk_g2_1
+(18 8) routing rgt_op_1 <X> lc_trk_g2_1
 (18 8) routing sp12_v_b_1 <X> lc_trk_g2_1
 (18 8) routing sp4_h_l_20 <X> lc_trk_g2_1
 (18 8) routing sp4_h_l_28 <X> lc_trk_g2_1
@@ -870,6 +1070,7 @@
 (19 10) Enable bit of Mux _span_links/cross_mux_vert_11 => sp12_v_b_23 sp4_v_t_10
 (19 11) Enable bit of Mux _span_links/cross_mux_vert_10 => sp12_v_b_21 sp4_v_b_22
 (19 12) Enable bit of Mux _span_links/cross_mux_horz_1 => sp12_h_r_2 sp4_h_r_13
+(19 13) Enable bit of Mux _span_links/cross_mux_horz_0 => sp12_h_r_0 sp4_h_r_12
 (19 14) Enable bit of Mux _span_links/cross_mux_horz_3 => sp12_h_l_5 sp4_h_l_2
 (19 15) Enable bit of Mux _span_links/cross_mux_horz_2 => sp12_h_l_3 sp4_h_l_3
 (19 2) Enable bit of Mux _span_links/cross_mux_vert_3 => sp12_v_b_7 sp4_v_t_2
@@ -880,11 +1081,17 @@
 (19 7) Enable bit of Mux _span_links/cross_mux_vert_6 => sp12_v_t_10 sp4_v_t_7
 (19 8) Enable bit of Mux _span_links/cross_mux_vert_9 => sp12_v_t_16 sp4_v_t_8
 (19 9) Enable bit of Mux _span_links/cross_mux_vert_8 => sp12_v_b_17 sp4_v_b_20
+(2 0) Enable bit of Mux _span_links/cross_mux_horz_4 => sp12_h_r_8 sp4_h_l_5
 (2 10) Enable bit of Mux _span_links/cross_mux_horz_9 => sp12_h_r_18 sp4_h_l_8
+(2 12) Enable bit of Mux _span_links/cross_mux_horz_10 => sp12_h_r_20 sp4_h_r_22
 (2 14) Enable bit of Mux _span_links/cross_mux_horz_11 => sp12_h_l_21 sp4_h_l_10
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_0 wire_bram/ram/WCLK
+(2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_1 wire_bram/ram/WCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_2 wire_bram/ram/WCLK
+(2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_3 wire_bram/ram/WCLK
+(2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_4 wire_bram/ram/WCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_5 wire_bram/ram/WCLK
+(2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_6 wire_bram/ram/WCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => glb_netwk_7 wire_bram/ram/WCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => lc_trk_g0_0 wire_bram/ram/WCLK
 (2 2) Enable bit of Mux _global_links/clk_mux => lc_trk_g1_1 wire_bram/ram/WCLK
@@ -894,14 +1101,19 @@
 (2 3) routing lc_trk_g1_1 <X> wire_bram/ram/WCLK
 (2 3) routing lc_trk_g2_0 <X> wire_bram/ram/WCLK
 (2 3) routing lc_trk_g3_1 <X> wire_bram/ram/WCLK
+(2 4) Enable bit of Mux _span_links/cross_mux_horz_6 => sp12_h_r_12 sp4_h_l_7
 (2 6) Enable bit of Mux _span_links/cross_mux_horz_7 => sp12_h_l_13 sp4_h_r_19
+(2 8) Enable bit of Mux _span_links/cross_mux_horz_8 => sp12_h_r_16 sp4_h_r_20
 (21 0) routing bnr_op_3 <X> lc_trk_g0_3
 (21 0) routing lft_op_3 <X> lc_trk_g0_3
+(21 0) routing sp12_h_l_0 <X> lc_trk_g0_3
 (21 0) routing sp4_h_r_11 <X> lc_trk_g0_3
 (21 0) routing sp4_h_r_19 <X> lc_trk_g0_3
 (21 0) routing sp4_v_b_11 <X> lc_trk_g0_3
 (21 0) routing sp4_v_b_3 <X> lc_trk_g0_3
 (21 1) routing bnr_op_3 <X> lc_trk_g0_3
+(21 1) routing sp12_h_l_0 <X> lc_trk_g0_3
+(21 1) routing sp12_h_l_16 <X> lc_trk_g0_3
 (21 1) routing sp4_h_r_19 <X> lc_trk_g0_3
 (21 1) routing sp4_h_r_3 <X> lc_trk_g0_3
 (21 1) routing sp4_r_v_b_32 <X> lc_trk_g0_3
@@ -916,9 +1128,11 @@
 (21 11) routing bnl_op_7 <X> lc_trk_g2_7
 (21 11) routing sp12_v_b_23 <X> lc_trk_g2_7
 (21 11) routing sp12_v_b_7 <X> lc_trk_g2_7
+(21 11) routing sp4_h_l_18 <X> lc_trk_g2_7
 (21 11) routing sp4_h_r_47 <X> lc_trk_g2_7
 (21 11) routing sp4_r_v_b_39 <X> lc_trk_g2_7
 (21 11) routing sp4_v_t_26 <X> lc_trk_g2_7
+(21 11) routing tnl_op_7 <X> lc_trk_g2_7
 (21 12) routing bnl_op_3 <X> lc_trk_g3_3
 (21 12) routing rgt_op_3 <X> lc_trk_g3_3
 (21 12) routing sp12_v_t_0 <X> lc_trk_g3_3
@@ -935,23 +1149,30 @@
 (21 13) routing sp4_v_t_22 <X> lc_trk_g3_3
 (21 13) routing tnl_op_3 <X> lc_trk_g3_3
 (21 14) routing bnl_op_7 <X> lc_trk_g3_7
+(21 14) routing rgt_op_7 <X> lc_trk_g3_7
 (21 14) routing sp12_v_b_7 <X> lc_trk_g3_7
+(21 14) routing sp4_h_l_26 <X> lc_trk_g3_7
 (21 14) routing sp4_h_r_47 <X> lc_trk_g3_7
 (21 14) routing sp4_v_t_18 <X> lc_trk_g3_7
 (21 14) routing sp4_v_t_26 <X> lc_trk_g3_7
 (21 15) routing bnl_op_7 <X> lc_trk_g3_7
 (21 15) routing sp12_v_b_23 <X> lc_trk_g3_7
 (21 15) routing sp12_v_b_7 <X> lc_trk_g3_7
+(21 15) routing sp4_h_l_18 <X> lc_trk_g3_7
 (21 15) routing sp4_h_r_47 <X> lc_trk_g3_7
 (21 15) routing sp4_r_v_b_47 <X> lc_trk_g3_7
 (21 15) routing sp4_v_t_26 <X> lc_trk_g3_7
 (21 15) routing tnl_op_7 <X> lc_trk_g3_7
 (21 2) routing bnr_op_7 <X> lc_trk_g0_7
 (21 2) routing lft_op_7 <X> lc_trk_g0_7
+(21 2) routing sp12_h_l_4 <X> lc_trk_g0_7
 (21 2) routing sp4_h_l_10 <X> lc_trk_g0_7
+(21 2) routing sp4_h_l_2 <X> lc_trk_g0_7
 (21 2) routing sp4_v_b_7 <X> lc_trk_g0_7
 (21 2) routing sp4_v_t_2 <X> lc_trk_g0_7
 (21 3) routing bnr_op_7 <X> lc_trk_g0_7
+(21 3) routing sp12_h_l_4 <X> lc_trk_g0_7
+(21 3) routing sp12_h_r_23 <X> lc_trk_g0_7
 (21 3) routing sp4_h_l_10 <X> lc_trk_g0_7
 (21 3) routing sp4_h_r_7 <X> lc_trk_g0_7
 (21 3) routing sp4_r_v_b_31 <X> lc_trk_g0_7
@@ -965,20 +1186,27 @@
 (21 4) routing sp4_v_b_3 <X> lc_trk_g1_3
 (21 5) routing bnr_op_3 <X> lc_trk_g1_3
 (21 5) routing sp12_h_l_0 <X> lc_trk_g1_3
+(21 5) routing sp12_h_l_16 <X> lc_trk_g1_3
 (21 5) routing sp4_h_r_19 <X> lc_trk_g1_3
 (21 5) routing sp4_h_r_3 <X> lc_trk_g1_3
 (21 5) routing sp4_r_v_b_27 <X> lc_trk_g1_3
 (21 5) routing sp4_v_b_11 <X> lc_trk_g1_3
+(21 6) routing bnr_op_7 <X> lc_trk_g1_7
 (21 6) routing lft_op_7 <X> lc_trk_g1_7
+(21 6) routing sp12_h_l_4 <X> lc_trk_g1_7
 (21 6) routing sp4_h_l_10 <X> lc_trk_g1_7
 (21 6) routing sp4_h_l_2 <X> lc_trk_g1_7
 (21 6) routing sp4_v_b_7 <X> lc_trk_g1_7
 (21 6) routing sp4_v_t_2 <X> lc_trk_g1_7
+(21 7) routing bnr_op_7 <X> lc_trk_g1_7
+(21 7) routing sp12_h_l_4 <X> lc_trk_g1_7
+(21 7) routing sp12_h_r_23 <X> lc_trk_g1_7
 (21 7) routing sp4_h_l_10 <X> lc_trk_g1_7
 (21 7) routing sp4_h_r_7 <X> lc_trk_g1_7
 (21 7) routing sp4_r_v_b_31 <X> lc_trk_g1_7
 (21 7) routing sp4_v_t_2 <X> lc_trk_g1_7
 (21 8) routing bnl_op_3 <X> lc_trk_g2_3
+(21 8) routing rgt_op_3 <X> lc_trk_g2_3
 (21 8) routing sp12_v_t_0 <X> lc_trk_g2_3
 (21 8) routing sp4_h_l_30 <X> lc_trk_g2_3
 (21 8) routing sp4_h_r_35 <X> lc_trk_g2_3
@@ -988,11 +1216,15 @@
 (21 9) routing sp12_v_t_0 <X> lc_trk_g2_3
 (21 9) routing sp12_v_t_16 <X> lc_trk_g2_3
 (21 9) routing sp4_h_l_30 <X> lc_trk_g2_3
+(21 9) routing sp4_h_r_27 <X> lc_trk_g2_3
 (21 9) routing sp4_r_v_b_35 <X> lc_trk_g2_3
 (21 9) routing sp4_v_t_22 <X> lc_trk_g2_3
 (21 9) routing tnl_op_3 <X> lc_trk_g2_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => bnr_op_3 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => lft_op_3 lc_trk_g0_3
+(22 0) Enable bit of Mux _local_links/g0_mux_3 => sp12_h_l_0 lc_trk_g0_3
+(22 0) Enable bit of Mux _local_links/g0_mux_3 => sp12_h_l_16 lc_trk_g0_3
+(22 0) Enable bit of Mux _local_links/g0_mux_3 => sp12_h_r_11 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_h_r_11 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_h_r_19 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_h_r_3 lc_trk_g0_3
@@ -1001,6 +1233,7 @@
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_v_b_11 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_v_b_19 lc_trk_g0_3
 (22 0) Enable bit of Mux _local_links/g0_mux_3 => sp4_v_b_3 lc_trk_g0_3
+(22 1) Enable bit of Mux _local_links/g0_mux_2 => bnr_op_2 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => lft_op_2 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp12_h_r_10 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp12_h_r_18 lc_trk_g0_2
@@ -1013,11 +1246,13 @@
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp4_v_b_10 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp4_v_b_2 lc_trk_g0_2
 (22 1) Enable bit of Mux _local_links/g0_mux_2 => sp4_v_t_7 lc_trk_g0_2
+(22 1) Enable bit of Mux _local_links/g0_mux_2 => top_op_2 lc_trk_g0_2
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => bnl_op_7 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => rgt_op_7 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp12_v_b_23 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp12_v_b_7 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp12_v_t_12 lc_trk_g2_7
+(22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_h_l_18 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_h_l_26 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_h_r_47 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_r_v_b_15 lc_trk_g2_7
@@ -1025,12 +1260,14 @@
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_v_b_47 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_v_t_18 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => sp4_v_t_26 lc_trk_g2_7
+(22 10) Enable bit of Mux _local_links/g2_mux_7 => tnl_op_7 lc_trk_g2_7
 (22 10) Enable bit of Mux _local_links/g2_mux_7 => tnr_op_7 lc_trk_g2_7
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => bnl_op_6 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => rgt_op_6 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp12_v_b_14 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp12_v_b_6 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp12_v_t_21 lc_trk_g2_6
+(22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_h_l_27 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_h_r_30 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_h_r_46 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_r_v_b_14 lc_trk_g2_6
@@ -1038,6 +1275,7 @@
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_v_b_30 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_v_b_38 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => sp4_v_b_46 lc_trk_g2_6
+(22 11) Enable bit of Mux _local_links/g2_mux_6 => tnl_op_6 lc_trk_g2_6
 (22 11) Enable bit of Mux _local_links/g2_mux_6 => tnr_op_6 lc_trk_g2_6
 (22 12) Enable bit of Mux _local_links/g3_mux_3 => bnl_op_3 lc_trk_g3_3
 (22 12) Enable bit of Mux _local_links/g3_mux_3 => rgt_op_3 lc_trk_g3_3
@@ -1067,11 +1305,15 @@
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => sp4_v_b_26 lc_trk_g3_2
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => sp4_v_t_23 lc_trk_g3_2
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => sp4_v_t_31 lc_trk_g3_2
+(22 13) Enable bit of Mux _local_links/g3_mux_2 => tnl_op_2 lc_trk_g3_2
 (22 13) Enable bit of Mux _local_links/g3_mux_2 => tnr_op_2 lc_trk_g3_2
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => bnl_op_7 lc_trk_g3_7
+(22 14) Enable bit of Mux _local_links/g3_mux_7 => rgt_op_7 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp12_v_b_23 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp12_v_b_7 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp12_v_t_12 lc_trk_g3_7
+(22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_h_l_18 lc_trk_g3_7
+(22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_h_l_26 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_h_r_47 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_r_v_b_23 lc_trk_g3_7
 (22 14) Enable bit of Mux _local_links/g3_mux_7 => sp4_r_v_b_47 lc_trk_g3_7
@@ -1098,7 +1340,11 @@
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => bnr_op_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => glb2local_3 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => lft_op_7 lc_trk_g0_7
+(22 2) Enable bit of Mux _local_links/g0_mux_7 => sp12_h_l_12 lc_trk_g0_7
+(22 2) Enable bit of Mux _local_links/g0_mux_7 => sp12_h_l_4 lc_trk_g0_7
+(22 2) Enable bit of Mux _local_links/g0_mux_7 => sp12_h_r_23 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_h_l_10 lc_trk_g0_7
+(22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_h_l_2 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_h_r_7 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_r_v_b_31 lc_trk_g0_7
 (22 2) Enable bit of Mux _local_links/g0_mux_7 => sp4_v_b_7 lc_trk_g0_7
@@ -1108,6 +1354,7 @@
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => glb2local_2 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => lft_op_6 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp12_h_l_13 lc_trk_g0_6
+(22 3) Enable bit of Mux _local_links/g0_mux_6 => sp12_h_l_21 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp12_h_l_5 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_h_l_3 lc_trk_g0_6
 (22 3) Enable bit of Mux _local_links/g0_mux_6 => sp4_h_r_22 lc_trk_g0_6
@@ -1120,6 +1367,8 @@
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => bnr_op_3 lc_trk_g1_3
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => lft_op_3 lc_trk_g1_3
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => sp12_h_l_0 lc_trk_g1_3
+(22 4) Enable bit of Mux _local_links/g1_mux_3 => sp12_h_l_16 lc_trk_g1_3
+(22 4) Enable bit of Mux _local_links/g1_mux_3 => sp12_h_r_11 lc_trk_g1_3
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => sp4_h_r_11 lc_trk_g1_3
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => sp4_h_r_19 lc_trk_g1_3
 (22 4) Enable bit of Mux _local_links/g1_mux_3 => sp4_h_r_3 lc_trk_g1_3
@@ -1131,15 +1380,22 @@
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => bnr_op_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => lft_op_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp12_h_r_10 lc_trk_g1_2
+(22 5) Enable bit of Mux _local_links/g1_mux_2 => sp12_h_r_18 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp12_h_r_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_h_l_7 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_h_r_10 lc_trk_g1_2
+(22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_h_r_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_r_v_b_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_r_v_b_26 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_v_b_10 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_v_b_2 lc_trk_g1_2
 (22 5) Enable bit of Mux _local_links/g1_mux_2 => sp4_v_t_7 lc_trk_g1_2
+(22 5) Enable bit of Mux _local_links/g1_mux_2 => top_op_2 lc_trk_g1_2
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => bnr_op_7 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => lft_op_7 lc_trk_g1_7
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => sp12_h_l_12 lc_trk_g1_7
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => sp12_h_l_4 lc_trk_g1_7
+(22 6) Enable bit of Mux _local_links/g1_mux_7 => sp12_h_r_23 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_h_l_10 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_h_l_2 lc_trk_g1_7
 (22 6) Enable bit of Mux _local_links/g1_mux_7 => sp4_h_r_7 lc_trk_g1_7
@@ -1155,16 +1411,20 @@
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp12_h_l_5 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_h_l_3 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_h_r_22 lc_trk_g1_6
+(22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_h_r_6 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_r_v_b_30 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_r_v_b_6 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_v_b_14 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_v_b_22 lc_trk_g1_6
 (22 7) Enable bit of Mux _local_links/g1_mux_6 => sp4_v_b_6 lc_trk_g1_6
+(22 7) Enable bit of Mux _local_links/g1_mux_6 => top_op_6 lc_trk_g1_6
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => bnl_op_3 lc_trk_g2_3
+(22 8) Enable bit of Mux _local_links/g2_mux_3 => rgt_op_3 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp12_v_b_11 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp12_v_t_0 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp12_v_t_16 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp4_h_l_30 lc_trk_g2_3
+(22 8) Enable bit of Mux _local_links/g2_mux_3 => sp4_h_r_27 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp4_h_r_35 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp4_r_v_b_11 lc_trk_g2_3
 (22 8) Enable bit of Mux _local_links/g2_mux_3 => sp4_r_v_b_35 lc_trk_g2_3
@@ -1178,6 +1438,7 @@
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp12_v_b_2 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp12_v_t_17 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp12_v_t_9 lc_trk_g2_2
+(22 9) Enable bit of Mux _local_links/g2_mux_2 => sp4_h_l_15 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp4_h_r_34 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp4_h_r_42 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp4_r_v_b_10 lc_trk_g2_2
@@ -1187,6 +1448,8 @@
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => sp4_v_t_31 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => tnl_op_2 lc_trk_g2_2
 (22 9) Enable bit of Mux _local_links/g2_mux_2 => tnr_op_2 lc_trk_g2_2
+(23 0) routing sp12_h_l_16 <X> lc_trk_g0_3
+(23 0) routing sp12_h_r_11 <X> lc_trk_g0_3
 (23 0) routing sp4_h_r_11 <X> lc_trk_g0_3
 (23 0) routing sp4_h_r_19 <X> lc_trk_g0_3
 (23 0) routing sp4_h_r_3 <X> lc_trk_g0_3
@@ -1203,6 +1466,7 @@
 (23 1) routing sp4_v_t_7 <X> lc_trk_g0_2
 (23 10) routing sp12_v_b_23 <X> lc_trk_g2_7
 (23 10) routing sp12_v_t_12 <X> lc_trk_g2_7
+(23 10) routing sp4_h_l_18 <X> lc_trk_g2_7
 (23 10) routing sp4_h_l_26 <X> lc_trk_g2_7
 (23 10) routing sp4_h_r_47 <X> lc_trk_g2_7
 (23 10) routing sp4_v_b_47 <X> lc_trk_g2_7
@@ -1210,6 +1474,7 @@
 (23 10) routing sp4_v_t_26 <X> lc_trk_g2_7
 (23 11) routing sp12_v_b_14 <X> lc_trk_g2_6
 (23 11) routing sp12_v_t_21 <X> lc_trk_g2_6
+(23 11) routing sp4_h_l_27 <X> lc_trk_g2_6
 (23 11) routing sp4_h_r_30 <X> lc_trk_g2_6
 (23 11) routing sp4_h_r_46 <X> lc_trk_g2_6
 (23 11) routing sp4_v_b_30 <X> lc_trk_g2_6
@@ -1233,6 +1498,8 @@
 (23 13) routing sp4_v_t_31 <X> lc_trk_g3_2
 (23 14) routing sp12_v_b_23 <X> lc_trk_g3_7
 (23 14) routing sp12_v_t_12 <X> lc_trk_g3_7
+(23 14) routing sp4_h_l_18 <X> lc_trk_g3_7
+(23 14) routing sp4_h_l_26 <X> lc_trk_g3_7
 (23 14) routing sp4_h_r_47 <X> lc_trk_g3_7
 (23 14) routing sp4_v_b_47 <X> lc_trk_g3_7
 (23 14) routing sp4_v_t_18 <X> lc_trk_g3_7
@@ -1245,18 +1512,24 @@
 (23 15) routing sp4_v_b_30 <X> lc_trk_g3_6
 (23 15) routing sp4_v_b_38 <X> lc_trk_g3_6
 (23 15) routing sp4_v_b_46 <X> lc_trk_g3_6
+(23 2) routing sp12_h_l_12 <X> lc_trk_g0_7
+(23 2) routing sp12_h_r_23 <X> lc_trk_g0_7
 (23 2) routing sp4_h_l_10 <X> lc_trk_g0_7
+(23 2) routing sp4_h_l_2 <X> lc_trk_g0_7
 (23 2) routing sp4_h_r_7 <X> lc_trk_g0_7
 (23 2) routing sp4_v_b_7 <X> lc_trk_g0_7
 (23 2) routing sp4_v_t_10 <X> lc_trk_g0_7
 (23 2) routing sp4_v_t_2 <X> lc_trk_g0_7
 (23 3) routing sp12_h_l_13 <X> lc_trk_g0_6
+(23 3) routing sp12_h_l_21 <X> lc_trk_g0_6
 (23 3) routing sp4_h_l_3 <X> lc_trk_g0_6
 (23 3) routing sp4_h_r_22 <X> lc_trk_g0_6
 (23 3) routing sp4_h_r_6 <X> lc_trk_g0_6
 (23 3) routing sp4_v_b_14 <X> lc_trk_g0_6
 (23 3) routing sp4_v_b_22 <X> lc_trk_g0_6
 (23 3) routing sp4_v_b_6 <X> lc_trk_g0_6
+(23 4) routing sp12_h_l_16 <X> lc_trk_g1_3
+(23 4) routing sp12_h_r_11 <X> lc_trk_g1_3
 (23 4) routing sp4_h_r_11 <X> lc_trk_g1_3
 (23 4) routing sp4_h_r_19 <X> lc_trk_g1_3
 (23 4) routing sp4_h_r_3 <X> lc_trk_g1_3
@@ -1264,11 +1537,15 @@
 (23 4) routing sp4_v_b_19 <X> lc_trk_g1_3
 (23 4) routing sp4_v_b_3 <X> lc_trk_g1_3
 (23 5) routing sp12_h_r_10 <X> lc_trk_g1_2
+(23 5) routing sp12_h_r_18 <X> lc_trk_g1_2
 (23 5) routing sp4_h_l_7 <X> lc_trk_g1_2
 (23 5) routing sp4_h_r_10 <X> lc_trk_g1_2
+(23 5) routing sp4_h_r_2 <X> lc_trk_g1_2
 (23 5) routing sp4_v_b_10 <X> lc_trk_g1_2
 (23 5) routing sp4_v_b_2 <X> lc_trk_g1_2
 (23 5) routing sp4_v_t_7 <X> lc_trk_g1_2
+(23 6) routing sp12_h_l_12 <X> lc_trk_g1_7
+(23 6) routing sp12_h_r_23 <X> lc_trk_g1_7
 (23 6) routing sp4_h_l_10 <X> lc_trk_g1_7
 (23 6) routing sp4_h_l_2 <X> lc_trk_g1_7
 (23 6) routing sp4_h_r_7 <X> lc_trk_g1_7
@@ -1279,24 +1556,28 @@
 (23 7) routing sp12_h_l_21 <X> lc_trk_g1_6
 (23 7) routing sp4_h_l_3 <X> lc_trk_g1_6
 (23 7) routing sp4_h_r_22 <X> lc_trk_g1_6
+(23 7) routing sp4_h_r_6 <X> lc_trk_g1_6
 (23 7) routing sp4_v_b_14 <X> lc_trk_g1_6
 (23 7) routing sp4_v_b_22 <X> lc_trk_g1_6
 (23 7) routing sp4_v_b_6 <X> lc_trk_g1_6
 (23 8) routing sp12_v_b_11 <X> lc_trk_g2_3
 (23 8) routing sp12_v_t_16 <X> lc_trk_g2_3
 (23 8) routing sp4_h_l_30 <X> lc_trk_g2_3
+(23 8) routing sp4_h_r_27 <X> lc_trk_g2_3
 (23 8) routing sp4_h_r_35 <X> lc_trk_g2_3
 (23 8) routing sp4_v_t_14 <X> lc_trk_g2_3
 (23 8) routing sp4_v_t_22 <X> lc_trk_g2_3
 (23 8) routing sp4_v_t_30 <X> lc_trk_g2_3
 (23 9) routing sp12_v_t_17 <X> lc_trk_g2_2
 (23 9) routing sp12_v_t_9 <X> lc_trk_g2_2
+(23 9) routing sp4_h_l_15 <X> lc_trk_g2_2
 (23 9) routing sp4_h_r_34 <X> lc_trk_g2_2
 (23 9) routing sp4_h_r_42 <X> lc_trk_g2_2
 (23 9) routing sp4_v_b_26 <X> lc_trk_g2_2
 (23 9) routing sp4_v_t_23 <X> lc_trk_g2_2
 (23 9) routing sp4_v_t_31 <X> lc_trk_g2_2
 (24 0) routing lft_op_3 <X> lc_trk_g0_3
+(24 0) routing sp12_h_l_0 <X> lc_trk_g0_3
 (24 0) routing sp4_h_r_11 <X> lc_trk_g0_3
 (24 0) routing sp4_h_r_19 <X> lc_trk_g0_3
 (24 0) routing sp4_h_r_3 <X> lc_trk_g0_3
@@ -1307,17 +1588,22 @@
 (24 1) routing sp4_h_r_10 <X> lc_trk_g0_2
 (24 1) routing sp4_h_r_2 <X> lc_trk_g0_2
 (24 1) routing sp4_v_t_7 <X> lc_trk_g0_2
+(24 1) routing top_op_2 <X> lc_trk_g0_2
 (24 10) routing rgt_op_7 <X> lc_trk_g2_7
 (24 10) routing sp12_v_b_7 <X> lc_trk_g2_7
+(24 10) routing sp4_h_l_18 <X> lc_trk_g2_7
 (24 10) routing sp4_h_l_26 <X> lc_trk_g2_7
 (24 10) routing sp4_h_r_47 <X> lc_trk_g2_7
 (24 10) routing sp4_v_b_47 <X> lc_trk_g2_7
+(24 10) routing tnl_op_7 <X> lc_trk_g2_7
 (24 10) routing tnr_op_7 <X> lc_trk_g2_7
 (24 11) routing rgt_op_6 <X> lc_trk_g2_6
 (24 11) routing sp12_v_b_6 <X> lc_trk_g2_6
+(24 11) routing sp4_h_l_27 <X> lc_trk_g2_6
 (24 11) routing sp4_h_r_30 <X> lc_trk_g2_6
 (24 11) routing sp4_h_r_46 <X> lc_trk_g2_6
 (24 11) routing sp4_v_b_46 <X> lc_trk_g2_6
+(24 11) routing tnl_op_6 <X> lc_trk_g2_6
 (24 11) routing tnr_op_6 <X> lc_trk_g2_6
 (24 12) routing rgt_op_3 <X> lc_trk_g3_3
 (24 12) routing sp12_v_t_0 <X> lc_trk_g3_3
@@ -1333,8 +1619,12 @@
 (24 13) routing sp4_h_r_34 <X> lc_trk_g3_2
 (24 13) routing sp4_h_r_42 <X> lc_trk_g3_2
 (24 13) routing sp4_v_t_31 <X> lc_trk_g3_2
+(24 13) routing tnl_op_2 <X> lc_trk_g3_2
 (24 13) routing tnr_op_2 <X> lc_trk_g3_2
+(24 14) routing rgt_op_7 <X> lc_trk_g3_7
 (24 14) routing sp12_v_b_7 <X> lc_trk_g3_7
+(24 14) routing sp4_h_l_18 <X> lc_trk_g3_7
+(24 14) routing sp4_h_l_26 <X> lc_trk_g3_7
 (24 14) routing sp4_h_r_47 <X> lc_trk_g3_7
 (24 14) routing sp4_v_b_47 <X> lc_trk_g3_7
 (24 14) routing tnl_op_7 <X> lc_trk_g3_7
@@ -1348,7 +1638,9 @@
 (24 15) routing tnl_op_6 <X> lc_trk_g3_6
 (24 15) routing tnr_op_6 <X> lc_trk_g3_6
 (24 2) routing lft_op_7 <X> lc_trk_g0_7
+(24 2) routing sp12_h_l_4 <X> lc_trk_g0_7
 (24 2) routing sp4_h_l_10 <X> lc_trk_g0_7
+(24 2) routing sp4_h_l_2 <X> lc_trk_g0_7
 (24 2) routing sp4_h_r_7 <X> lc_trk_g0_7
 (24 2) routing sp4_v_t_10 <X> lc_trk_g0_7
 (24 3) routing lft_op_6 <X> lc_trk_g0_6
@@ -1368,8 +1660,11 @@
 (24 5) routing sp12_h_r_2 <X> lc_trk_g1_2
 (24 5) routing sp4_h_l_7 <X> lc_trk_g1_2
 (24 5) routing sp4_h_r_10 <X> lc_trk_g1_2
+(24 5) routing sp4_h_r_2 <X> lc_trk_g1_2
 (24 5) routing sp4_v_t_7 <X> lc_trk_g1_2
+(24 5) routing top_op_2 <X> lc_trk_g1_2
 (24 6) routing lft_op_7 <X> lc_trk_g1_7
+(24 6) routing sp12_h_l_4 <X> lc_trk_g1_7
 (24 6) routing sp4_h_l_10 <X> lc_trk_g1_7
 (24 6) routing sp4_h_l_2 <X> lc_trk_g1_7
 (24 6) routing sp4_h_r_7 <X> lc_trk_g1_7
@@ -1378,35 +1673,44 @@
 (24 7) routing sp12_h_l_5 <X> lc_trk_g1_6
 (24 7) routing sp4_h_l_3 <X> lc_trk_g1_6
 (24 7) routing sp4_h_r_22 <X> lc_trk_g1_6
+(24 7) routing sp4_h_r_6 <X> lc_trk_g1_6
 (24 7) routing sp4_v_b_22 <X> lc_trk_g1_6
+(24 7) routing top_op_6 <X> lc_trk_g1_6
+(24 8) routing rgt_op_3 <X> lc_trk_g2_3
 (24 8) routing sp12_v_t_0 <X> lc_trk_g2_3
 (24 8) routing sp4_h_l_30 <X> lc_trk_g2_3
+(24 8) routing sp4_h_r_27 <X> lc_trk_g2_3
 (24 8) routing sp4_h_r_35 <X> lc_trk_g2_3
 (24 8) routing sp4_v_t_30 <X> lc_trk_g2_3
 (24 8) routing tnl_op_3 <X> lc_trk_g2_3
 (24 8) routing tnr_op_3 <X> lc_trk_g2_3
 (24 9) routing rgt_op_2 <X> lc_trk_g2_2
 (24 9) routing sp12_v_b_2 <X> lc_trk_g2_2
+(24 9) routing sp4_h_l_15 <X> lc_trk_g2_2
 (24 9) routing sp4_h_r_34 <X> lc_trk_g2_2
 (24 9) routing sp4_h_r_42 <X> lc_trk_g2_2
 (24 9) routing sp4_v_t_31 <X> lc_trk_g2_2
 (24 9) routing tnl_op_2 <X> lc_trk_g2_2
 (24 9) routing tnr_op_2 <X> lc_trk_g2_2
+(25 0) routing bnr_op_2 <X> lc_trk_g0_2
 (25 0) routing lft_op_2 <X> lc_trk_g0_2
 (25 0) routing sp12_h_r_2 <X> lc_trk_g0_2
 (25 0) routing sp4_h_l_7 <X> lc_trk_g0_2
 (25 0) routing sp4_h_r_10 <X> lc_trk_g0_2
 (25 0) routing sp4_v_b_10 <X> lc_trk_g0_2
 (25 0) routing sp4_v_b_2 <X> lc_trk_g0_2
+(25 1) routing bnr_op_2 <X> lc_trk_g0_2
 (25 1) routing sp12_h_r_18 <X> lc_trk_g0_2
 (25 1) routing sp12_h_r_2 <X> lc_trk_g0_2
 (25 1) routing sp4_h_l_7 <X> lc_trk_g0_2
 (25 1) routing sp4_h_r_2 <X> lc_trk_g0_2
 (25 1) routing sp4_r_v_b_33 <X> lc_trk_g0_2
 (25 1) routing sp4_v_b_10 <X> lc_trk_g0_2
+(25 1) routing top_op_2 <X> lc_trk_g0_2
 (25 10) routing bnl_op_6 <X> lc_trk_g2_6
 (25 10) routing rgt_op_6 <X> lc_trk_g2_6
 (25 10) routing sp12_v_b_6 <X> lc_trk_g2_6
+(25 10) routing sp4_h_l_27 <X> lc_trk_g2_6
 (25 10) routing sp4_h_r_46 <X> lc_trk_g2_6
 (25 10) routing sp4_v_b_30 <X> lc_trk_g2_6
 (25 10) routing sp4_v_b_38 <X> lc_trk_g2_6
@@ -1417,6 +1721,7 @@
 (25 11) routing sp4_h_r_46 <X> lc_trk_g2_6
 (25 11) routing sp4_r_v_b_38 <X> lc_trk_g2_6
 (25 11) routing sp4_v_b_38 <X> lc_trk_g2_6
+(25 11) routing tnl_op_6 <X> lc_trk_g2_6
 (25 12) routing bnl_op_2 <X> lc_trk_g3_2
 (25 12) routing rgt_op_2 <X> lc_trk_g3_2
 (25 12) routing sp12_v_b_2 <X> lc_trk_g3_2
@@ -1431,6 +1736,7 @@
 (25 13) routing sp4_h_r_42 <X> lc_trk_g3_2
 (25 13) routing sp4_r_v_b_42 <X> lc_trk_g3_2
 (25 13) routing sp4_v_t_23 <X> lc_trk_g3_2
+(25 13) routing tnl_op_2 <X> lc_trk_g3_2
 (25 14) routing bnl_op_6 <X> lc_trk_g3_6
 (25 14) routing rgt_op_6 <X> lc_trk_g3_6
 (25 14) routing sp12_v_b_6 <X> lc_trk_g3_6
@@ -1454,6 +1760,7 @@
 (25 2) routing sp4_v_b_14 <X> lc_trk_g0_6
 (25 2) routing sp4_v_b_6 <X> lc_trk_g0_6
 (25 3) routing bnr_op_6 <X> lc_trk_g0_6
+(25 3) routing sp12_h_l_21 <X> lc_trk_g0_6
 (25 3) routing sp12_h_l_5 <X> lc_trk_g0_6
 (25 3) routing sp4_h_r_22 <X> lc_trk_g0_6
 (25 3) routing sp4_h_r_6 <X> lc_trk_g0_6
@@ -1468,10 +1775,13 @@
 (25 4) routing sp4_v_b_10 <X> lc_trk_g1_2
 (25 4) routing sp4_v_b_2 <X> lc_trk_g1_2
 (25 5) routing bnr_op_2 <X> lc_trk_g1_2
+(25 5) routing sp12_h_r_18 <X> lc_trk_g1_2
 (25 5) routing sp12_h_r_2 <X> lc_trk_g1_2
 (25 5) routing sp4_h_l_7 <X> lc_trk_g1_2
+(25 5) routing sp4_h_r_2 <X> lc_trk_g1_2
 (25 5) routing sp4_r_v_b_26 <X> lc_trk_g1_2
 (25 5) routing sp4_v_b_10 <X> lc_trk_g1_2
+(25 5) routing top_op_2 <X> lc_trk_g1_2
 (25 6) routing bnr_op_6 <X> lc_trk_g1_6
 (25 6) routing lft_op_6 <X> lc_trk_g1_6
 (25 6) routing sp12_h_l_5 <X> lc_trk_g1_6
@@ -1483,8 +1793,10 @@
 (25 7) routing sp12_h_l_21 <X> lc_trk_g1_6
 (25 7) routing sp12_h_l_5 <X> lc_trk_g1_6
 (25 7) routing sp4_h_r_22 <X> lc_trk_g1_6
+(25 7) routing sp4_h_r_6 <X> lc_trk_g1_6
 (25 7) routing sp4_r_v_b_30 <X> lc_trk_g1_6
 (25 7) routing sp4_v_b_14 <X> lc_trk_g1_6
+(25 7) routing top_op_6 <X> lc_trk_g1_6
 (25 8) routing bnl_op_2 <X> lc_trk_g2_2
 (25 8) routing rgt_op_2 <X> lc_trk_g2_2
 (25 8) routing sp12_v_b_2 <X> lc_trk_g2_2
@@ -1495,6 +1807,7 @@
 (25 9) routing bnl_op_2 <X> lc_trk_g2_2
 (25 9) routing sp12_v_b_2 <X> lc_trk_g2_2
 (25 9) routing sp12_v_t_17 <X> lc_trk_g2_2
+(25 9) routing sp4_h_l_15 <X> lc_trk_g2_2
 (25 9) routing sp4_h_r_42 <X> lc_trk_g2_2
 (25 9) routing sp4_r_v_b_34 <X> lc_trk_g2_2
 (25 9) routing sp4_v_t_23 <X> lc_trk_g2_2
@@ -1632,6 +1945,7 @@
 (27 0) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_7
 (27 0) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_7
 (27 0) routing lc_trk_g3_0 <X> wire_bram/ram/WDATA_7
+(27 0) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_7
 (27 0) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_7
 (27 0) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_7
 (27 1) routing lc_trk_g1_1 <X> input0_0
@@ -1644,6 +1958,7 @@
 (27 1) routing lc_trk_g3_7 <X> input0_0
 (27 10) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_2
 (27 10) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_2
+(27 10) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_2
 (27 10) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_2
 (27 10) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_2
 (27 10) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_2
@@ -1674,6 +1989,7 @@
 (27 13) routing lc_trk_g3_5 <X> input0_6
 (27 13) routing lc_trk_g3_7 <X> input0_6
 (27 14) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_0
+(27 14) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_0
 (27 14) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_0
 (27 14) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_0
 (27 14) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_0
@@ -1688,6 +2004,7 @@
 (27 15) routing lc_trk_g3_2 <X> input0_7
 (27 15) routing lc_trk_g3_4 <X> input0_7
 (27 15) routing lc_trk_g3_6 <X> input0_7
+(27 2) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_6
 (27 2) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_6
 (27 2) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_6
 (27 2) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_6
@@ -1719,8 +2036,10 @@
 (27 5) routing lc_trk_g3_3 <X> input0_2
 (27 5) routing lc_trk_g3_5 <X> input0_2
 (27 5) routing lc_trk_g3_7 <X> input0_2
+(27 6) routing lc_trk_g1_1 <X> wire_bram/ram/WDATA_4
 (27 6) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_4
 (27 6) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_4
+(27 6) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_4
 (27 6) routing lc_trk_g3_1 <X> wire_bram/ram/WDATA_4
 (27 6) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_4
 (27 6) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_4
@@ -1751,8 +2070,10 @@
 (27 9) routing lc_trk_g3_7 <X> input0_4
 (28 0) routing lc_trk_g2_1 <X> wire_bram/ram/WDATA_7
 (28 0) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_7
+(28 0) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_7
 (28 0) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_7
 (28 0) routing lc_trk_g3_0 <X> wire_bram/ram/WDATA_7
+(28 0) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_7
 (28 0) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_7
 (28 0) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_7
 (28 1) routing lc_trk_g2_0 <X> input0_0
@@ -1843,6 +2164,7 @@
 (28 5) routing lc_trk_g3_3 <X> input0_2
 (28 5) routing lc_trk_g3_5 <X> input0_2
 (28 5) routing lc_trk_g3_7 <X> input0_2
+(28 6) routing lc_trk_g2_0 <X> wire_bram/ram/WDATA_4
 (28 6) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_4
 (28 6) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_4
 (28 6) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_4
@@ -1876,6 +2198,7 @@
 (28 9) routing lc_trk_g3_7 <X> input0_4
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_1 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_3 wire_bram/ram/WDATA_7
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_5 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g0_7 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_0 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_2 wire_bram/ram/WDATA_7
@@ -1883,8 +2206,10 @@
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g1_6 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_1 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_3 wire_bram/ram/WDATA_7
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_5 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g2_7 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_0 wire_bram/ram/WDATA_7
+(29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_2 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_4 wire_bram/ram/WDATA_7
 (29 0) Enable bit of Mux _bram/lcb1_0 => lc_trk_g3_6 wire_bram/ram/WDATA_7
 (29 1) Enable bit of Mux _bram/lcb0_0 => lc_trk_g0_0 input0_0
@@ -1903,11 +2228,13 @@
 (29 1) Enable bit of Mux _bram/lcb0_0 => lc_trk_g3_3 input0_0
 (29 1) Enable bit of Mux _bram/lcb0_0 => lc_trk_g3_5 input0_0
 (29 1) Enable bit of Mux _bram/lcb0_0 => lc_trk_g3_7 input0_0
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g0_0 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g0_2 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g0_4 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g0_6 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_1 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_3 wire_bram/ram/WDATA_2
+(29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_5 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g1_7 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g2_0 wire_bram/ram/WDATA_2
 (29 10) Enable bit of Mux _bram/lcb1_5 => lc_trk_g2_2 wire_bram/ram/WDATA_2
@@ -1970,6 +2297,7 @@
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g0_4 wire_bram/ram/WDATA_0
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g0_6 wire_bram/ram/WDATA_0
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_1 wire_bram/ram/WDATA_0
+(29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_3 wire_bram/ram/WDATA_0
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_5 wire_bram/ram/WDATA_0
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g1_7 wire_bram/ram/WDATA_0
 (29 14) Enable bit of Mux _bram/lcb1_7 => lc_trk_g2_0 wire_bram/ram/WDATA_0
@@ -2000,6 +2328,7 @@
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_2 wire_bram/ram/WDATA_6
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_4 wire_bram/ram/WDATA_6
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g0_6 wire_bram/ram/WDATA_6
+(29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_1 wire_bram/ram/WDATA_6
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_3 wire_bram/ram/WDATA_6
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_5 wire_bram/ram/WDATA_6
 (29 2) Enable bit of Mux _bram/lcb1_1 => lc_trk_g1_7 wire_bram/ram/WDATA_6
@@ -2063,8 +2392,11 @@
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g0_2 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g0_4 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g0_6 wire_bram/ram/WDATA_4
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_1 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_3 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_5 wire_bram/ram/WDATA_4
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g1_7 wire_bram/ram/WDATA_4
+(29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_0 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_2 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_4 wire_bram/ram/WDATA_4
 (29 6) Enable bit of Mux _bram/lcb1_3 => lc_trk_g2_6 wire_bram/ram/WDATA_4
@@ -2088,6 +2420,7 @@
 (29 7) Enable bit of Mux _bram/lcb0_3 => lc_trk_g3_2 input0_3
 (29 7) Enable bit of Mux _bram/lcb0_3 => lc_trk_g3_4 input0_3
 (29 7) Enable bit of Mux _bram/lcb0_3 => lc_trk_g3_6 input0_3
+(29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_1 wire_bram/ram/WDATA_3
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_3 wire_bram/ram/WDATA_3
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_5 wire_bram/ram/WDATA_3
 (29 8) Enable bit of Mux _bram/lcb1_4 => lc_trk_g0_7 wire_bram/ram/WDATA_3
@@ -2123,7 +2456,9 @@
 (3 0) routing sp12_v_t_23 <X> sp12_v_b_0
 (3 1) routing sp12_h_l_23 <X> sp12_v_b_0
 (3 1) routing sp12_h_r_0 <X> sp12_v_b_0
+(3 10) routing sp12_h_r_1 <X> sp12_h_l_22
 (3 10) routing sp12_v_t_22 <X> sp12_h_l_22
+(3 11) routing sp12_h_r_1 <X> sp12_h_l_22
 (3 11) routing sp12_v_b_1 <X> sp12_h_l_22
 (3 12) routing sp12_v_b_1 <X> sp12_h_r_1
 (3 12) routing sp12_v_t_22 <X> sp12_h_r_1
@@ -2149,9 +2484,11 @@
 (3 8) routing sp12_v_t_22 <X> sp12_v_b_1
 (3 9) routing sp12_h_l_22 <X> sp12_v_b_1
 (3 9) routing sp12_h_r_1 <X> sp12_v_b_1
+(30 0) routing lc_trk_g0_5 <X> wire_bram/ram/WDATA_7
 (30 0) routing lc_trk_g0_7 <X> wire_bram/ram/WDATA_7
 (30 0) routing lc_trk_g1_4 <X> wire_bram/ram/WDATA_7
 (30 0) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_7
+(30 0) routing lc_trk_g2_5 <X> wire_bram/ram/WDATA_7
 (30 0) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_7
 (30 0) routing lc_trk_g3_4 <X> wire_bram/ram/WDATA_7
 (30 0) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_7
@@ -2161,9 +2498,11 @@
 (30 1) routing lc_trk_g1_6 <X> wire_bram/ram/WDATA_7
 (30 1) routing lc_trk_g2_3 <X> wire_bram/ram/WDATA_7
 (30 1) routing lc_trk_g2_7 <X> wire_bram/ram/WDATA_7
+(30 1) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_7
 (30 1) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_7
 (30 10) routing lc_trk_g0_4 <X> wire_bram/ram/WDATA_2
 (30 10) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_2
+(30 10) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_2
 (30 10) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_2
 (30 10) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_2
 (30 10) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_2
@@ -2203,6 +2542,7 @@
 (30 14) routing lc_trk_g3_7 <X> wire_bram/ram/WDATA_0
 (30 15) routing lc_trk_g0_2 <X> wire_bram/ram/WDATA_0
 (30 15) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_0
+(30 15) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_0
 (30 15) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_0
 (30 15) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_0
 (30 15) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_0
@@ -2243,6 +2583,7 @@
 (30 6) routing lc_trk_g0_4 <X> wire_bram/ram/WDATA_4
 (30 6) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_4
 (30 6) routing lc_trk_g1_5 <X> wire_bram/ram/WDATA_4
+(30 6) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_4
 (30 6) routing lc_trk_g2_4 <X> wire_bram/ram/WDATA_4
 (30 6) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_4
 (30 6) routing lc_trk_g3_5 <X> wire_bram/ram/WDATA_4
@@ -2250,6 +2591,7 @@
 (30 7) routing lc_trk_g0_2 <X> wire_bram/ram/WDATA_4
 (30 7) routing lc_trk_g0_6 <X> wire_bram/ram/WDATA_4
 (30 7) routing lc_trk_g1_3 <X> wire_bram/ram/WDATA_4
+(30 7) routing lc_trk_g1_7 <X> wire_bram/ram/WDATA_4
 (30 7) routing lc_trk_g2_2 <X> wire_bram/ram/WDATA_4
 (30 7) routing lc_trk_g2_6 <X> wire_bram/ram/WDATA_4
 (30 7) routing lc_trk_g3_3 <X> wire_bram/ram/WDATA_4
@@ -2271,111 +2613,188 @@
 (30 9) routing lc_trk_g3_2 <X> wire_bram/ram/WDATA_3
 (30 9) routing lc_trk_g3_6 <X> wire_bram/ram/WDATA_3
 (31 0) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_7
+(31 0) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_7
+(31 0) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_7
+(31 0) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_7
 (31 0) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_7
 (31 0) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_7
+(31 0) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_7
+(31 0) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_7
+(31 1) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_7
+(31 1) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_7
+(31 1) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_7
+(31 1) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_7
+(31 1) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_7
 (31 1) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_7
 (31 1) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_7
+(31 1) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_7
 (31 10) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_2
+(31 10) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_2
 (31 10) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_2
+(31 10) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_2
 (31 10) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_2
+(31 10) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_2
 (31 10) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_2
 (31 10) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_2
 (31 11) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_2
+(31 11) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_2
 (31 11) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_2
+(31 11) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_2
+(31 11) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_2
+(31 11) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_2
 (31 11) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_2
 (31 11) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_2
 (31 12) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_1
 (31 12) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_1
 (31 12) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_1
+(31 12) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_1
 (31 12) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_1
 (31 12) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_1
 (31 12) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_1
 (31 12) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_1
+(31 13) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_1
 (31 13) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_1
+(31 13) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_1
+(31 13) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_1
+(31 13) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_1
 (31 13) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_1
 (31 13) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_1
 (31 13) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_1
+(31 14) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_0
 (31 14) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_0
+(31 14) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_0
 (31 14) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_0
 (31 14) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_0
 (31 14) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_0
 (31 14) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_0
 (31 14) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_0
+(31 15) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_0
 (31 15) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_0
+(31 15) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_0
 (31 15) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_0
+(31 15) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_0
 (31 15) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_0
 (31 15) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_0
 (31 15) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_0
+(31 2) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_6
 (31 2) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_6
 (31 2) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_6
+(31 2) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_6
+(31 2) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_6
 (31 2) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_6
 (31 2) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_6
 (31 2) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_6
+(31 3) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_6
 (31 3) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_6
+(31 3) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_6
+(31 3) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_6
 (31 3) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_6
 (31 3) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_6
 (31 3) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_6
 (31 3) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_6
+(31 4) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_5
+(31 4) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_5
+(31 4) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_5
 (31 4) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_5
 (31 4) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_5
 (31 4) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_5
 (31 4) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_5
 (31 4) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_5
+(31 5) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_5
+(31 5) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_5
+(31 5) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_5
 (31 5) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_5
+(31 5) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_5
 (31 5) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_5
+(31 5) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_5
 (31 5) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_5
 (31 6) routing lc_trk_g0_4 <X> wire_bram/ram/MASK_4
+(31 6) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_4
 (31 6) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_4
+(31 6) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_4
 (31 6) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_4
+(31 6) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_4
 (31 6) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_4
 (31 6) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_4
 (31 7) routing lc_trk_g0_2 <X> wire_bram/ram/MASK_4
+(31 7) routing lc_trk_g0_6 <X> wire_bram/ram/MASK_4
+(31 7) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_4
+(31 7) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_4
 (31 7) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_4
+(31 7) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_4
 (31 7) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_4
 (31 7) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_4
 (31 8) routing lc_trk_g0_5 <X> wire_bram/ram/MASK_3
+(31 8) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_3
+(31 8) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_3
+(31 8) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_3
 (31 8) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_3
 (31 8) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_3
 (31 8) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_3
 (31 8) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_3
 (31 9) routing lc_trk_g0_3 <X> wire_bram/ram/MASK_3
+(31 9) routing lc_trk_g0_7 <X> wire_bram/ram/MASK_3
 (31 9) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_3
+(31 9) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_3
 (31 9) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_3
 (31 9) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_3
 (31 9) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_3
 (31 9) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_3
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g0_3 wire_bram/ram/MASK_7
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g0_5 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g0_7 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_0 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_2 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_4 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g1_6 wire_bram/ram/MASK_7
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_1 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_3 wire_bram/ram/MASK_7
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_5 wire_bram/ram/MASK_7
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g2_7 wire_bram/ram/MASK_7
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_0 wire_bram/ram/MASK_7
 (32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_2 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_4 wire_bram/ram/MASK_7
+(32 0) Enable bit of Mux _bram/lcb3_0 => lc_trk_g3_6 wire_bram/ram/MASK_7
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g0_2 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g0_4 wire_bram/ram/MASK_2
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g0_6 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_1 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_3 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_5 wire_bram/ram/MASK_2
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g1_7 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_0 wire_bram/ram/MASK_2
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_2 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_4 wire_bram/ram/MASK_2
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g2_6 wire_bram/ram/MASK_2
+(32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_1 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_3 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_5 wire_bram/ram/MASK_2
 (32 10) Enable bit of Mux _bram/lcb3_5 => lc_trk_g3_7 wire_bram/ram/MASK_2
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_1 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_3 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_5 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g0_7 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_0 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_2 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_4 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g1_6 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_1 input2_5
+(32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_3 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_5 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g2_7 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_0 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_2 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_4 input2_5
 (32 11) Enable bit of Mux _bram/lcb2_5 => lc_trk_g3_6 input2_5
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g0_3 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g0_5 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g0_7 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_0 wire_bram/ram/MASK_1
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_2 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_4 wire_bram/ram/MASK_1
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g1_6 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g2_1 wire_bram/ram/MASK_1
+(32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g2_3 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g2_5 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g2_7 wire_bram/ram/MASK_1
 (32 12) Enable bit of Mux _bram/lcb3_6 => lc_trk_g3_0 wire_bram/ram/MASK_1
@@ -2398,10 +2817,15 @@
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g3_3 input2_6
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g3_5 input2_6
 (32 13) Enable bit of Mux _bram/lcb2_6 => lc_trk_g3_7 input2_6
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g0_2 wire_bram/ram/MASK_0
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g0_4 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g0_6 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_1 wire_bram/ram/MASK_0
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_3 wire_bram/ram/MASK_0
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_5 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g1_7 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_0 wire_bram/ram/MASK_0
+(32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_2 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_4 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g2_6 wire_bram/ram/MASK_0
 (32 14) Enable bit of Mux _bram/lcb3_7 => lc_trk_g3_1 wire_bram/ram/MASK_0
@@ -2424,54 +2848,84 @@
 (32 15) Enable bit of Mux _bram/lcb2_7 => lc_trk_g3_2 input2_7
 (32 15) Enable bit of Mux _bram/lcb2_7 => lc_trk_g3_4 input2_7
 (32 15) Enable bit of Mux _bram/lcb2_7 => lc_trk_g3_6 input2_7
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g0_2 wire_bram/ram/MASK_6
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g0_4 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g0_6 wire_bram/ram/MASK_6
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_1 wire_bram/ram/MASK_6
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_3 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_5 wire_bram/ram/MASK_6
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g1_7 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_0 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_2 wire_bram/ram/MASK_6
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_4 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g2_6 wire_bram/ram/MASK_6
+(32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_1 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_3 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_5 wire_bram/ram/MASK_6
 (32 2) Enable bit of Mux _bram/lcb3_1 => lc_trk_g3_7 wire_bram/ram/MASK_6
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g0_3 wire_bram/ram/MASK_5
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g0_5 wire_bram/ram/MASK_5
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g0_7 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_0 wire_bram/ram/MASK_5
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_2 wire_bram/ram/MASK_5
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_4 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g1_6 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_1 wire_bram/ram/MASK_5
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_3 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_5 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g2_7 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_0 wire_bram/ram/MASK_5
+(32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_2 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_4 wire_bram/ram/MASK_5
 (32 4) Enable bit of Mux _bram/lcb3_2 => lc_trk_g3_6 wire_bram/ram/MASK_5
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g0_2 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g0_4 wire_bram/ram/MASK_4
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g0_6 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_1 wire_bram/ram/MASK_4
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_3 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_5 wire_bram/ram/MASK_4
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g1_7 wire_bram/ram/MASK_4
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_0 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_2 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_4 wire_bram/ram/MASK_4
+(32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g2_6 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_1 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_3 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_5 wire_bram/ram/MASK_4
 (32 6) Enable bit of Mux _bram/lcb3_3 => lc_trk_g3_7 wire_bram/ram/MASK_4
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g0_3 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g0_5 wire_bram/ram/MASK_3
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g0_7 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_0 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_2 wire_bram/ram/MASK_3
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_4 wire_bram/ram/MASK_3
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g1_6 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_1 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_3 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_5 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g2_7 wire_bram/ram/MASK_3
+(32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_0 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_2 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_4 wire_bram/ram/MASK_3
 (32 8) Enable bit of Mux _bram/lcb3_4 => lc_trk_g3_6 wire_bram/ram/MASK_3
 (33 0) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_7
+(33 0) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_7
 (33 0) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_7
 (33 0) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_7
 (33 0) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_7
 (33 0) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_7
+(33 0) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_7
+(33 0) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_7
 (33 10) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_2
+(33 10) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_2
 (33 10) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_2
+(33 10) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_2
+(33 10) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_2
 (33 10) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_2
 (33 10) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_2
 (33 10) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_2
 (33 11) routing lc_trk_g2_1 <X> input2_5
+(33 11) routing lc_trk_g2_3 <X> input2_5
 (33 11) routing lc_trk_g2_5 <X> input2_5
 (33 11) routing lc_trk_g2_7 <X> input2_5
 (33 11) routing lc_trk_g3_0 <X> input2_5
@@ -2479,6 +2933,7 @@
 (33 11) routing lc_trk_g3_4 <X> input2_5
 (33 11) routing lc_trk_g3_6 <X> input2_5
 (33 12) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_1
+(33 12) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_1
 (33 12) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_1
 (33 12) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_1
 (33 12) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_1
@@ -2494,6 +2949,7 @@
 (33 13) routing lc_trk_g3_5 <X> input2_6
 (33 13) routing lc_trk_g3_7 <X> input2_6
 (33 14) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_0
+(33 14) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_0
 (33 14) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_0
 (33 14) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_0
 (33 14) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_0
@@ -2510,18 +2966,24 @@
 (33 15) routing lc_trk_g3_6 <X> input2_7
 (33 2) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_6
 (33 2) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_6
+(33 2) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_6
 (33 2) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_6
+(33 2) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_6
 (33 2) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_6
 (33 2) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_6
 (33 2) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_6
 (33 4) routing lc_trk_g2_1 <X> wire_bram/ram/MASK_5
+(33 4) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_5
 (33 4) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_5
 (33 4) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_5
 (33 4) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_5
+(33 4) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_5
 (33 4) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_5
 (33 4) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_5
+(33 6) routing lc_trk_g2_0 <X> wire_bram/ram/MASK_4
 (33 6) routing lc_trk_g2_2 <X> wire_bram/ram/MASK_4
 (33 6) routing lc_trk_g2_4 <X> wire_bram/ram/MASK_4
+(33 6) routing lc_trk_g2_6 <X> wire_bram/ram/MASK_4
 (33 6) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_4
 (33 6) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_4
 (33 6) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_4
@@ -2530,17 +2992,28 @@
 (33 8) routing lc_trk_g2_3 <X> wire_bram/ram/MASK_3
 (33 8) routing lc_trk_g2_5 <X> wire_bram/ram/MASK_3
 (33 8) routing lc_trk_g2_7 <X> wire_bram/ram/MASK_3
+(33 8) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_3
 (33 8) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_3
 (33 8) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_3
 (33 8) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_3
+(34 0) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_7
+(34 0) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_7
+(34 0) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_7
+(34 0) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_7
 (34 0) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_7
 (34 0) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_7
+(34 0) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_7
+(34 0) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_7
 (34 10) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_2
 (34 10) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_2
 (34 10) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_2
+(34 10) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_2
+(34 10) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_2
 (34 10) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_2
 (34 10) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_2
 (34 10) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_2
+(34 11) routing lc_trk_g1_0 <X> input2_5
+(34 11) routing lc_trk_g1_2 <X> input2_5
 (34 11) routing lc_trk_g1_4 <X> input2_5
 (34 11) routing lc_trk_g1_6 <X> input2_5
 (34 11) routing lc_trk_g3_0 <X> input2_5
@@ -2548,7 +3021,9 @@
 (34 11) routing lc_trk_g3_4 <X> input2_5
 (34 11) routing lc_trk_g3_6 <X> input2_5
 (34 12) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_1
+(34 12) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_1
 (34 12) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_1
+(34 12) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_1
 (34 12) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_1
 (34 12) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_1
 (34 12) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_1
@@ -2562,6 +3037,8 @@
 (34 13) routing lc_trk_g3_5 <X> input2_6
 (34 13) routing lc_trk_g3_7 <X> input2_6
 (34 14) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_0
+(34 14) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_0
+(34 14) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_0
 (34 14) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_0
 (34 14) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_0
 (34 14) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_0
@@ -2575,26 +3052,40 @@
 (34 15) routing lc_trk_g3_2 <X> input2_7
 (34 15) routing lc_trk_g3_4 <X> input2_7
 (34 15) routing lc_trk_g3_6 <X> input2_7
+(34 2) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_6
+(34 2) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_6
 (34 2) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_6
+(34 2) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_6
+(34 2) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_6
 (34 2) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_6
 (34 2) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_6
 (34 2) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_6
 (34 4) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_5
+(34 4) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_5
+(34 4) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_5
 (34 4) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_5
 (34 4) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_5
+(34 4) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_5
 (34 4) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_5
 (34 4) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_5
 (34 6) routing lc_trk_g1_1 <X> wire_bram/ram/MASK_4
+(34 6) routing lc_trk_g1_3 <X> wire_bram/ram/MASK_4
 (34 6) routing lc_trk_g1_5 <X> wire_bram/ram/MASK_4
+(34 6) routing lc_trk_g1_7 <X> wire_bram/ram/MASK_4
 (34 6) routing lc_trk_g3_1 <X> wire_bram/ram/MASK_4
 (34 6) routing lc_trk_g3_3 <X> wire_bram/ram/MASK_4
 (34 6) routing lc_trk_g3_5 <X> wire_bram/ram/MASK_4
 (34 6) routing lc_trk_g3_7 <X> wire_bram/ram/MASK_4
 (34 8) routing lc_trk_g1_0 <X> wire_bram/ram/MASK_3
 (34 8) routing lc_trk_g1_2 <X> wire_bram/ram/MASK_3
+(34 8) routing lc_trk_g1_4 <X> wire_bram/ram/MASK_3
+(34 8) routing lc_trk_g1_6 <X> wire_bram/ram/MASK_3
+(34 8) routing lc_trk_g3_0 <X> wire_bram/ram/MASK_3
 (34 8) routing lc_trk_g3_2 <X> wire_bram/ram/MASK_3
 (34 8) routing lc_trk_g3_4 <X> wire_bram/ram/MASK_3
 (34 8) routing lc_trk_g3_6 <X> wire_bram/ram/MASK_3
+(35 10) routing lc_trk_g0_5 <X> input2_5
+(35 10) routing lc_trk_g0_7 <X> input2_5
 (35 10) routing lc_trk_g1_4 <X> input2_5
 (35 10) routing lc_trk_g1_6 <X> input2_5
 (35 10) routing lc_trk_g2_5 <X> input2_5
@@ -2602,7 +3093,10 @@
 (35 10) routing lc_trk_g3_4 <X> input2_5
 (35 10) routing lc_trk_g3_6 <X> input2_5
 (35 11) routing lc_trk_g0_3 <X> input2_5
+(35 11) routing lc_trk_g0_7 <X> input2_5
+(35 11) routing lc_trk_g1_2 <X> input2_5
 (35 11) routing lc_trk_g1_6 <X> input2_5
+(35 11) routing lc_trk_g2_3 <X> input2_5
 (35 11) routing lc_trk_g2_7 <X> input2_5
 (35 11) routing lc_trk_g3_2 <X> input2_5
 (35 11) routing lc_trk_g3_6 <X> input2_5
@@ -2644,12 +3138,16 @@
 (36 11) Enable bit of Mux _out_links/OutMux6_5 => wire_bram/ram/RDATA_2 sp4_h_r_10
 (36 12) Enable bit of Mux _out_links/OutMux8_6 => wire_bram/ram/RDATA_1 sp4_h_r_44
 (36 13) Enable bit of Mux _out_links/OutMux6_6 => wire_bram/ram/RDATA_1 sp4_h_r_12
+(36 14) Enable bit of Mux _out_links/OutMux8_7 => wire_bram/ram/RDATA_0 sp4_h_r_46
 (36 15) Enable bit of Mux _out_links/OutMux6_7 => wire_bram/ram/RDATA_0 sp4_h_l_3
 (36 2) Enable bit of Mux _out_links/OutMux8_1 => wire_bram/ram/RDATA_6 sp4_h_r_34
 (36 3) Enable bit of Mux _out_links/OutMux6_1 => wire_bram/ram/RDATA_6 sp4_h_r_2
 (36 4) Enable bit of Mux _out_links/OutMux8_2 => wire_bram/ram/RDATA_5 sp4_h_r_36
+(36 5) Enable bit of Mux _out_links/OutMux6_2 => wire_bram/ram/RDATA_5 sp4_h_r_4
 (36 6) Enable bit of Mux _out_links/OutMux8_3 => wire_bram/ram/RDATA_4 sp4_h_l_27
 (36 7) Enable bit of Mux _out_links/OutMux6_3 => wire_bram/ram/RDATA_4 sp4_h_r_6
+(36 8) Enable bit of Mux _out_links/OutMux8_4 => wire_bram/ram/RDATA_3 sp4_h_l_29
+(36 9) Enable bit of Mux _out_links/OutMux6_4 => wire_bram/ram/RDATA_3 sp4_h_r_8
 (37 0) Enable bit of Mux _out_links/OutMux5_0 => wire_bram/ram/RDATA_7 sp12_h_r_8
 (37 1) Enable bit of Mux _out_links/OutMux7_0 => wire_bram/ram/RDATA_7 sp4_h_l_5
 (37 10) Enable bit of Mux _out_links/OutMux4_5 => wire_bram/ram/RDATA_2 sp12_h_r_2
@@ -2680,6 +3178,7 @@
 (38 5) Enable bit of Mux _out_links/OutMux0_2 => wire_bram/ram/RDATA_5 sp4_v_b_4
 (38 6) Enable bit of Mux _out_links/OutMux2_3 => wire_bram/ram/RDATA_4 sp4_v_b_38
 (38 7) Enable bit of Mux _out_links/OutMux0_3 => wire_bram/ram/RDATA_4 sp4_v_b_6
+(38 8) Enable bit of Mux _out_links/OutMux1_4 => wire_bram/ram/RDATA_3 sp4_v_t_13
 (38 9) Enable bit of Mux _out_links/OutMux5_4 => wire_bram/ram/RDATA_3 sp12_h_r_16
 (39 0) Enable bit of Mux _out_links/OutMux3_0 => wire_bram/ram/RDATA_7 sp12_v_b_0
 (39 1) Enable bit of Mux _out_links/OutMux1_0 => wire_bram/ram/RDATA_7 sp4_v_b_16
@@ -2701,44 +3200,65 @@
 (4 0) routing sp4_h_l_43 <X> sp4_v_b_0
 (4 0) routing sp4_v_t_37 <X> sp4_v_b_0
 (4 0) routing sp4_v_t_41 <X> sp4_v_b_0
+(4 1) routing sp4_h_l_41 <X> sp4_h_r_0
+(4 1) routing sp4_h_l_44 <X> sp4_h_r_0
+(4 1) routing sp4_v_b_6 <X> sp4_h_r_0
+(4 1) routing sp4_v_t_42 <X> sp4_h_r_0
 (4 10) routing sp4_h_r_0 <X> sp4_v_t_43
+(4 10) routing sp4_h_r_6 <X> sp4_v_t_43
 (4 10) routing sp4_v_b_10 <X> sp4_v_t_43
 (4 10) routing sp4_v_b_6 <X> sp4_v_t_43
 (4 11) routing sp4_h_r_10 <X> sp4_h_l_43
+(4 11) routing sp4_h_r_3 <X> sp4_h_l_43
 (4 11) routing sp4_v_b_1 <X> sp4_h_l_43
 (4 11) routing sp4_v_t_37 <X> sp4_h_l_43
 (4 12) routing sp4_h_l_38 <X> sp4_v_b_9
 (4 12) routing sp4_h_l_44 <X> sp4_v_b_9
 (4 12) routing sp4_v_t_36 <X> sp4_v_b_9
 (4 12) routing sp4_v_t_44 <X> sp4_v_b_9
+(4 13) routing sp4_h_l_36 <X> sp4_h_r_9
 (4 13) routing sp4_h_l_43 <X> sp4_h_r_9
+(4 13) routing sp4_v_b_3 <X> sp4_h_r_9
 (4 13) routing sp4_v_t_41 <X> sp4_h_r_9
 (4 14) routing sp4_h_r_3 <X> sp4_v_t_44
 (4 14) routing sp4_h_r_9 <X> sp4_v_t_44
 (4 14) routing sp4_v_b_1 <X> sp4_v_t_44
 (4 14) routing sp4_v_b_9 <X> sp4_v_t_44
+(4 15) routing sp4_h_r_1 <X> sp4_h_l_44
+(4 15) routing sp4_h_r_6 <X> sp4_h_l_44
 (4 15) routing sp4_v_b_4 <X> sp4_h_l_44
 (4 15) routing sp4_v_t_38 <X> sp4_h_l_44
+(4 2) routing sp4_h_r_0 <X> sp4_v_t_37
 (4 2) routing sp4_h_r_6 <X> sp4_v_t_37
 (4 2) routing sp4_v_b_0 <X> sp4_v_t_37
 (4 2) routing sp4_v_b_4 <X> sp4_v_t_37
+(4 3) routing sp4_h_r_4 <X> sp4_h_l_37
+(4 3) routing sp4_h_r_9 <X> sp4_h_l_37
 (4 3) routing sp4_v_b_7 <X> sp4_h_l_37
+(4 3) routing sp4_v_t_43 <X> sp4_h_l_37
 (4 4) routing sp4_h_l_38 <X> sp4_v_b_3
 (4 4) routing sp4_h_l_44 <X> sp4_v_b_3
 (4 4) routing sp4_v_t_38 <X> sp4_v_b_3
 (4 4) routing sp4_v_t_42 <X> sp4_v_b_3
+(4 5) routing sp4_h_l_37 <X> sp4_h_r_3
+(4 5) routing sp4_h_l_42 <X> sp4_h_r_3
 (4 5) routing sp4_v_b_9 <X> sp4_h_r_3
+(4 5) routing sp4_v_t_47 <X> sp4_h_r_3
 (4 6) routing sp4_h_r_3 <X> sp4_v_t_38
 (4 6) routing sp4_h_r_9 <X> sp4_v_t_38
 (4 6) routing sp4_v_b_3 <X> sp4_v_t_38
 (4 6) routing sp4_v_b_7 <X> sp4_v_t_38
 (4 7) routing sp4_h_r_0 <X> sp4_h_l_38
+(4 7) routing sp4_h_r_7 <X> sp4_h_l_38
 (4 7) routing sp4_v_b_10 <X> sp4_h_l_38
 (4 7) routing sp4_v_t_44 <X> sp4_h_l_38
 (4 8) routing sp4_h_l_37 <X> sp4_v_b_6
 (4 8) routing sp4_h_l_43 <X> sp4_v_b_6
 (4 8) routing sp4_v_t_43 <X> sp4_v_b_6
 (4 8) routing sp4_v_t_47 <X> sp4_v_b_6
+(4 9) routing sp4_h_l_38 <X> sp4_h_r_6
+(4 9) routing sp4_h_l_47 <X> sp4_h_r_6
+(4 9) routing sp4_v_b_0 <X> sp4_h_r_6
 (4 9) routing sp4_v_t_36 <X> sp4_h_r_6
 (40 0) Enable bit of Mux _out_links/OutMuxa_0 => wire_bram/ram/RDATA_7 sp4_r_v_b_17
 (40 1) Enable bit of Mux _out_links/OutMux4_0 => wire_bram/ram/RDATA_7 sp12_v_b_16
@@ -2772,24 +3292,31 @@
 (41 7) Enable bit of Mux _out_links/OutMux9_3 => wire_bram/ram/RDATA_4 sp4_r_v_b_7
 (41 8) Enable bit of Mux _out_links/OutMuxb_4 => wire_bram/ram/RDATA_3 sp4_r_v_b_41
 (41 9) Enable bit of Mux _out_links/OutMux9_4 => wire_bram/ram/RDATA_3 sp4_r_v_b_9
+(5 0) routing sp4_h_l_44 <X> sp4_h_r_0
+(5 0) routing sp4_v_b_0 <X> sp4_h_r_0
+(5 0) routing sp4_v_b_6 <X> sp4_h_r_0
 (5 0) routing sp4_v_t_37 <X> sp4_h_r_0
 (5 1) routing sp4_h_l_37 <X> sp4_v_b_0
 (5 1) routing sp4_h_l_43 <X> sp4_v_b_0
 (5 1) routing sp4_h_r_0 <X> sp4_v_b_0
 (5 1) routing sp4_v_t_44 <X> sp4_v_b_0
+(5 10) routing sp4_h_r_3 <X> sp4_h_l_43
 (5 10) routing sp4_v_b_6 <X> sp4_h_l_43
 (5 10) routing sp4_v_t_37 <X> sp4_h_l_43
 (5 10) routing sp4_v_t_43 <X> sp4_h_l_43
 (5 11) routing sp4_h_l_43 <X> sp4_v_t_43
 (5 11) routing sp4_h_r_0 <X> sp4_v_t_43
+(5 11) routing sp4_h_r_6 <X> sp4_v_t_43
 (5 11) routing sp4_v_b_3 <X> sp4_v_t_43
 (5 12) routing sp4_h_l_43 <X> sp4_h_r_9
+(5 12) routing sp4_v_b_3 <X> sp4_h_r_9
 (5 12) routing sp4_v_b_9 <X> sp4_h_r_9
 (5 12) routing sp4_v_t_44 <X> sp4_h_r_9
 (5 13) routing sp4_h_l_38 <X> sp4_v_b_9
 (5 13) routing sp4_h_l_44 <X> sp4_v_b_9
 (5 13) routing sp4_h_r_9 <X> sp4_v_b_9
 (5 13) routing sp4_v_t_43 <X> sp4_v_b_9
+(5 14) routing sp4_h_r_6 <X> sp4_h_l_44
 (5 14) routing sp4_v_b_9 <X> sp4_h_l_44
 (5 14) routing sp4_v_t_38 <X> sp4_h_l_44
 (5 14) routing sp4_v_t_44 <X> sp4_h_l_44
@@ -2797,24 +3324,34 @@
 (5 15) routing sp4_h_r_3 <X> sp4_v_t_44
 (5 15) routing sp4_h_r_9 <X> sp4_v_t_44
 (5 15) routing sp4_v_b_6 <X> sp4_v_t_44
+(5 2) routing sp4_h_r_9 <X> sp4_h_l_37
 (5 2) routing sp4_v_b_0 <X> sp4_h_l_37
 (5 2) routing sp4_v_t_37 <X> sp4_h_l_37
+(5 2) routing sp4_v_t_43 <X> sp4_h_l_37
 (5 3) routing sp4_h_l_37 <X> sp4_v_t_37
+(5 3) routing sp4_h_r_0 <X> sp4_v_t_37
 (5 3) routing sp4_h_r_6 <X> sp4_v_t_37
 (5 3) routing sp4_v_b_9 <X> sp4_v_t_37
+(5 4) routing sp4_h_l_37 <X> sp4_h_r_3
+(5 4) routing sp4_v_b_3 <X> sp4_h_r_3
 (5 4) routing sp4_v_b_9 <X> sp4_h_r_3
+(5 4) routing sp4_v_t_38 <X> sp4_h_r_3
 (5 5) routing sp4_h_l_38 <X> sp4_v_b_3
 (5 5) routing sp4_h_l_44 <X> sp4_v_b_3
 (5 5) routing sp4_h_r_3 <X> sp4_v_b_3
 (5 5) routing sp4_v_t_37 <X> sp4_v_b_3
 (5 6) routing sp4_h_r_0 <X> sp4_h_l_38
 (5 6) routing sp4_v_b_3 <X> sp4_h_l_38
+(5 6) routing sp4_v_t_38 <X> sp4_h_l_38
 (5 6) routing sp4_v_t_44 <X> sp4_h_l_38
 (5 7) routing sp4_h_l_38 <X> sp4_v_t_38
 (5 7) routing sp4_h_r_3 <X> sp4_v_t_38
 (5 7) routing sp4_h_r_9 <X> sp4_v_t_38
 (5 7) routing sp4_v_b_0 <X> sp4_v_t_38
+(5 8) routing sp4_h_l_38 <X> sp4_h_r_6
+(5 8) routing sp4_v_b_0 <X> sp4_h_r_6
 (5 8) routing sp4_v_b_6 <X> sp4_h_r_6
+(5 8) routing sp4_v_t_43 <X> sp4_h_r_6
 (5 9) routing sp4_h_l_37 <X> sp4_v_b_6
 (5 9) routing sp4_h_l_43 <X> sp4_v_b_6
 (5 9) routing sp4_h_r_6 <X> sp4_v_b_6
@@ -2824,6 +3361,9 @@
 (6 0) routing sp4_v_t_41 <X> sp4_v_b_0
 (6 0) routing sp4_v_t_44 <X> sp4_v_b_0
 (6 1) routing sp4_h_l_37 <X> sp4_h_r_0
+(6 1) routing sp4_h_l_41 <X> sp4_h_r_0
+(6 1) routing sp4_v_b_0 <X> sp4_h_r_0
+(6 1) routing sp4_v_b_6 <X> sp4_h_r_0
 (6 10) routing sp4_h_l_36 <X> sp4_v_t_43
 (6 10) routing sp4_h_r_0 <X> sp4_v_t_43
 (6 10) routing sp4_v_b_10 <X> sp4_v_t_43
@@ -2836,10 +3376,15 @@
 (6 12) routing sp4_h_r_4 <X> sp4_v_b_9
 (6 12) routing sp4_v_t_36 <X> sp4_v_b_9
 (6 12) routing sp4_v_t_43 <X> sp4_v_b_9
+(6 13) routing sp4_h_l_36 <X> sp4_h_r_9
+(6 13) routing sp4_h_l_44 <X> sp4_h_r_9
+(6 13) routing sp4_v_b_3 <X> sp4_h_r_9
 (6 13) routing sp4_v_b_9 <X> sp4_h_r_9
+(6 14) routing sp4_h_l_41 <X> sp4_v_t_44
 (6 14) routing sp4_h_r_3 <X> sp4_v_t_44
 (6 14) routing sp4_v_b_1 <X> sp4_v_t_44
 (6 14) routing sp4_v_b_6 <X> sp4_v_t_44
+(6 15) routing sp4_h_r_1 <X> sp4_h_l_44
 (6 15) routing sp4_h_r_9 <X> sp4_h_l_44
 (6 15) routing sp4_v_t_38 <X> sp4_h_l_44
 (6 15) routing sp4_v_t_44 <X> sp4_h_l_44
@@ -2847,20 +3392,33 @@
 (6 2) routing sp4_h_r_6 <X> sp4_v_t_37
 (6 2) routing sp4_v_b_4 <X> sp4_v_t_37
 (6 2) routing sp4_v_b_9 <X> sp4_v_t_37
+(6 3) routing sp4_h_r_0 <X> sp4_h_l_37
+(6 3) routing sp4_h_r_4 <X> sp4_h_l_37
 (6 3) routing sp4_v_t_37 <X> sp4_h_l_37
+(6 3) routing sp4_v_t_43 <X> sp4_h_l_37
 (6 4) routing sp4_h_l_44 <X> sp4_v_b_3
 (6 4) routing sp4_h_r_10 <X> sp4_v_b_3
 (6 4) routing sp4_v_t_37 <X> sp4_v_b_3
 (6 4) routing sp4_v_t_42 <X> sp4_v_b_3
+(6 5) routing sp4_h_l_38 <X> sp4_h_r_3
+(6 5) routing sp4_h_l_42 <X> sp4_h_r_3
+(6 5) routing sp4_v_b_3 <X> sp4_h_r_3
 (6 5) routing sp4_v_b_9 <X> sp4_h_r_3
 (6 6) routing sp4_h_l_47 <X> sp4_v_t_38
 (6 6) routing sp4_h_r_9 <X> sp4_v_t_38
 (6 6) routing sp4_v_b_0 <X> sp4_v_t_38
 (6 6) routing sp4_v_b_7 <X> sp4_v_t_38
+(6 7) routing sp4_h_r_3 <X> sp4_h_l_38
+(6 7) routing sp4_h_r_7 <X> sp4_h_l_38
+(6 7) routing sp4_v_t_38 <X> sp4_h_l_38
 (6 7) routing sp4_v_t_44 <X> sp4_h_l_38
 (6 8) routing sp4_h_l_37 <X> sp4_v_b_6
+(6 8) routing sp4_h_r_1 <X> sp4_v_b_6
 (6 8) routing sp4_v_t_38 <X> sp4_v_b_6
 (6 8) routing sp4_v_t_47 <X> sp4_v_b_6
+(6 9) routing sp4_h_l_43 <X> sp4_h_r_6
+(6 9) routing sp4_h_l_47 <X> sp4_h_r_6
+(6 9) routing sp4_v_b_0 <X> sp4_h_r_6
 (6 9) routing sp4_v_b_6 <X> sp4_h_r_6
 (7 0) Ram config bit: MEMT_bram_cbit_1
 (7 1) Ram config bit: MEMT_bram_cbit_0
@@ -2878,6 +3436,7 @@
 (7 4) Cascade buffer Enable bit: MEMT_LC03_inmux00_bram_cbit_5
 (7 4) Cascade buffer Enable bit: MEMT_LC04_inmux00_bram_cbit_5
 (7 4) Cascade buffer Enable bit: MEMT_LC05_inmux00_bram_cbit_5
+(7 4) Cascade buffer Enable bit: MEMT_LC06_inmux00_bram_cbit_5
 (7 4) Cascade buffer Enable bit: MEMT_LC06_inmux02_bram_cbit_5
 (7 4) Cascade buffer Enable bit: MEMT_LC07_inmux00_bram_cbit_5
 (7 4) Cascade buffer Enable bit: MEMT_LC07_inmux02_bram_cbit_5
@@ -2887,6 +3446,7 @@
 (7 5) Cascade bit: MEMT_LC03_inmux00_bram_cbit_4
 (7 5) Cascade bit: MEMT_LC04_inmux00_bram_cbit_4
 (7 5) Cascade bit: MEMT_LC05_inmux00_bram_cbit_4
+(7 5) Cascade bit: MEMT_LC06_inmux00_bram_cbit_4
 (7 5) Cascade bit: MEMT_LC06_inmux02_bram_cbit_4
 (7 5) Cascade bit: MEMT_LC07_inmux00_bram_cbit_4
 (7 5) Cascade bit: MEMT_LC07_inmux02_bram_cbit_4
@@ -2912,27 +3472,40 @@
 (7 7) Cascade bit: MEMT_LC07_inmux02_bram_cbit_6
 (7 8) Column buffer control bit: MEMT_colbuf_cntl_1
 (7 9) Column buffer control bit: MEMT_colbuf_cntl_0
+(8 0) routing sp4_h_l_36 <X> sp4_h_r_1
+(8 0) routing sp4_h_l_40 <X> sp4_h_r_1
+(8 0) routing sp4_v_b_1 <X> sp4_h_r_1
+(8 0) routing sp4_v_b_7 <X> sp4_h_r_1
 (8 1) routing sp4_h_l_36 <X> sp4_v_b_1
 (8 1) routing sp4_h_l_42 <X> sp4_v_b_1
 (8 1) routing sp4_h_r_1 <X> sp4_v_b_1
 (8 1) routing sp4_v_t_47 <X> sp4_v_b_1
 (8 10) routing sp4_h_r_11 <X> sp4_h_l_42
+(8 10) routing sp4_h_r_7 <X> sp4_h_l_42
 (8 10) routing sp4_v_t_36 <X> sp4_h_l_42
 (8 10) routing sp4_v_t_42 <X> sp4_h_l_42
+(8 11) routing sp4_h_l_42 <X> sp4_v_t_42
 (8 11) routing sp4_h_r_1 <X> sp4_v_t_42
 (8 11) routing sp4_h_r_7 <X> sp4_v_t_42
 (8 11) routing sp4_v_b_4 <X> sp4_v_t_42
+(8 12) routing sp4_h_l_39 <X> sp4_h_r_10
+(8 12) routing sp4_h_l_47 <X> sp4_h_r_10
+(8 12) routing sp4_v_b_10 <X> sp4_h_r_10
 (8 12) routing sp4_v_b_4 <X> sp4_h_r_10
 (8 13) routing sp4_h_l_41 <X> sp4_v_b_10
 (8 13) routing sp4_h_l_47 <X> sp4_v_b_10
 (8 13) routing sp4_h_r_10 <X> sp4_v_b_10
 (8 13) routing sp4_v_t_42 <X> sp4_v_b_10
 (8 14) routing sp4_h_r_10 <X> sp4_h_l_47
+(8 14) routing sp4_h_r_2 <X> sp4_h_l_47
 (8 14) routing sp4_v_t_41 <X> sp4_h_l_47
 (8 14) routing sp4_v_t_47 <X> sp4_h_l_47
 (8 15) routing sp4_h_l_47 <X> sp4_v_t_47
 (8 15) routing sp4_h_r_10 <X> sp4_v_t_47
+(8 15) routing sp4_h_r_4 <X> sp4_v_t_47
 (8 15) routing sp4_v_b_7 <X> sp4_v_t_47
+(8 2) routing sp4_h_r_1 <X> sp4_h_l_36
+(8 2) routing sp4_h_r_5 <X> sp4_h_l_36
 (8 2) routing sp4_v_t_36 <X> sp4_h_l_36
 (8 2) routing sp4_v_t_42 <X> sp4_h_l_36
 (8 3) routing sp4_h_l_36 <X> sp4_v_t_36
@@ -2945,37 +3518,54 @@
 (8 4) routing sp4_v_b_4 <X> sp4_h_r_4
 (8 5) routing sp4_h_l_41 <X> sp4_v_b_4
 (8 5) routing sp4_h_l_47 <X> sp4_v_b_4
+(8 5) routing sp4_h_r_4 <X> sp4_v_b_4
 (8 5) routing sp4_v_t_36 <X> sp4_v_b_4
+(8 6) routing sp4_h_r_4 <X> sp4_h_l_41
+(8 6) routing sp4_h_r_8 <X> sp4_h_l_41
 (8 6) routing sp4_v_t_41 <X> sp4_h_l_41
 (8 6) routing sp4_v_t_47 <X> sp4_h_l_41
 (8 7) routing sp4_h_l_41 <X> sp4_v_t_41
 (8 7) routing sp4_h_r_10 <X> sp4_v_t_41
+(8 7) routing sp4_h_r_4 <X> sp4_v_t_41
 (8 7) routing sp4_v_b_1 <X> sp4_v_t_41
+(8 8) routing sp4_h_l_42 <X> sp4_h_r_7
+(8 8) routing sp4_h_l_46 <X> sp4_h_r_7
 (8 8) routing sp4_v_b_1 <X> sp4_h_r_7
+(8 8) routing sp4_v_b_7 <X> sp4_h_r_7
 (8 9) routing sp4_h_l_36 <X> sp4_v_b_7
 (8 9) routing sp4_h_l_42 <X> sp4_v_b_7
 (8 9) routing sp4_h_r_7 <X> sp4_v_b_7
 (8 9) routing sp4_v_t_41 <X> sp4_v_b_7
+(9 0) routing sp4_h_l_47 <X> sp4_h_r_1
+(9 0) routing sp4_v_b_1 <X> sp4_h_r_1
+(9 0) routing sp4_v_b_7 <X> sp4_h_r_1
 (9 0) routing sp4_v_t_36 <X> sp4_h_r_1
 (9 1) routing sp4_h_l_36 <X> sp4_v_b_1
 (9 1) routing sp4_h_l_42 <X> sp4_v_b_1
 (9 1) routing sp4_v_t_36 <X> sp4_v_b_1
 (9 1) routing sp4_v_t_40 <X> sp4_v_b_1
+(9 10) routing sp4_h_r_4 <X> sp4_h_l_42
+(9 10) routing sp4_v_b_7 <X> sp4_h_l_42
 (9 10) routing sp4_v_t_36 <X> sp4_h_l_42
 (9 10) routing sp4_v_t_42 <X> sp4_h_l_42
 (9 11) routing sp4_h_r_1 <X> sp4_v_t_42
 (9 11) routing sp4_h_r_7 <X> sp4_v_t_42
 (9 11) routing sp4_v_b_11 <X> sp4_v_t_42
 (9 11) routing sp4_v_b_7 <X> sp4_v_t_42
+(9 12) routing sp4_h_l_42 <X> sp4_h_r_10
+(9 12) routing sp4_v_b_10 <X> sp4_h_r_10
 (9 12) routing sp4_v_b_4 <X> sp4_h_r_10
 (9 12) routing sp4_v_t_47 <X> sp4_h_r_10
 (9 13) routing sp4_h_l_41 <X> sp4_v_b_10
 (9 13) routing sp4_h_l_47 <X> sp4_v_b_10
 (9 13) routing sp4_v_t_39 <X> sp4_v_b_10
 (9 13) routing sp4_v_t_47 <X> sp4_v_b_10
+(9 14) routing sp4_h_r_7 <X> sp4_h_l_47
+(9 14) routing sp4_v_b_10 <X> sp4_h_l_47
 (9 14) routing sp4_v_t_41 <X> sp4_h_l_47
 (9 14) routing sp4_v_t_47 <X> sp4_h_l_47
 (9 15) routing sp4_h_r_10 <X> sp4_v_t_47
+(9 15) routing sp4_h_r_4 <X> sp4_v_t_47
 (9 15) routing sp4_v_b_10 <X> sp4_v_t_47
 (9 15) routing sp4_v_b_2 <X> sp4_v_t_47
 (9 2) routing sp4_h_r_10 <X> sp4_h_l_36
@@ -2986,6 +3576,7 @@
 (9 3) routing sp4_h_r_7 <X> sp4_v_t_36
 (9 3) routing sp4_v_b_1 <X> sp4_v_t_36
 (9 3) routing sp4_v_b_5 <X> sp4_v_t_36
+(9 4) routing sp4_h_l_36 <X> sp4_h_r_4
 (9 4) routing sp4_v_b_10 <X> sp4_h_r_4
 (9 4) routing sp4_v_b_4 <X> sp4_h_r_4
 (9 4) routing sp4_v_t_41 <X> sp4_h_r_4
@@ -2998,9 +3589,13 @@
 (9 6) routing sp4_v_t_41 <X> sp4_h_l_41
 (9 6) routing sp4_v_t_47 <X> sp4_h_l_41
 (9 7) routing sp4_h_r_10 <X> sp4_v_t_41
+(9 7) routing sp4_h_r_4 <X> sp4_v_t_41
 (9 7) routing sp4_v_b_4 <X> sp4_v_t_41
 (9 7) routing sp4_v_b_8 <X> sp4_v_t_41
+(9 8) routing sp4_h_l_41 <X> sp4_h_r_7
 (9 8) routing sp4_v_b_1 <X> sp4_h_r_7
+(9 8) routing sp4_v_b_7 <X> sp4_h_r_7
+(9 8) routing sp4_v_t_42 <X> sp4_h_r_7
 (9 9) routing sp4_h_l_36 <X> sp4_v_b_7
 (9 9) routing sp4_h_l_42 <X> sp4_v_b_7
 (9 9) routing sp4_v_t_42 <X> sp4_v_b_7

--- a/icefuzz/tests/colbuf_5k.sh
+++ b/icefuzz/tests/colbuf_5k.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+for f in colbuf_io_5k.work/*.exp colbuf_logic_5k.work/*.exp colbuf_ram_5k.work/*.exp; do
+	echo $f >&2
+	python3 colbuf.py $f
+done | sort -u > colbuf_5k.txt
+
+get_colbuf_data()
+{
+	tr -d '(,)' < colbuf_5k.txt
+	# for x in {0..2} {4..9} {11..13}; do
+	# 	echo $x 4 $x 0
+	# 	echo $x 5 $x 8
+	# 	echo $x 12 $x 9
+	# 	echo $x 13 $x 17
+	# done
+	# for x in 3 10; do
+	# 	echo $x 3 $x 0
+	# 	echo $x 3 $x 4
+	# 	echo $x 5 $x 8
+	# 	echo $x 11 $x 9
+	# 	echo $x 11 $x 12
+	# 	echo $x 13 $x 17
+	# done
+}
+
+{
+	echo "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"1050\" width=\"1050\">"
+	for x in {1..33}; do
+		echo "<line x1=\"$((10+x*30))\" y1=\"10\" x2=\"$((10+x*30))\" y2=\"$((10+34*30))\" style=\"stroke:rgb(0,0,0);stroke-width:3\" />"
+	done
+	for y in {1..33}; do
+		echo "<line x1=\"10\" y1=\"$((10+y*30))\" x2=\"$((10+34*30))\" y2=\"$((10+y*30))\" style=\"stroke:rgb(0,0,0);stroke-width:3\" />"
+	done
+	for x in {0..33}; do
+		echo "<text x=\"$((10+$x*30+7))\" y=\"$((10+34*30+15))\" fill=\"black\">$x</text>"
+	done
+	for y in {0..33}; do
+		echo "<text x=\"$((10+34*30+5))\" y=\"$((10+(33-y)*30+20))\" fill=\"black\">$y</text>"
+	done
+	while read x1 y1 x2 y2; do
+		echo "<line x1=\"$((10+x1*30+15))\" y1=\"$((10+(33-y1)*30+15))\" x2=\"$((10+x2*30+15))\" y2=\"$((10+(33-y2)*30+15))\" style=\"stroke:rgb(255,0,0);stroke-width:5\" />"
+	done < <( get_colbuf_data; )
+	while read x1 y1 x2 y2; do
+		echo "<circle cx=\"$((10+x2*30+15))\" cy=\"$((10+(33-y2)*30+15))\" r=\"4\" fill=\"blue\" />"
+	done < <( get_colbuf_data; )
+	while read x1 y1 x2 y2; do
+		echo "<circle cx=\"$((10+x1*30+15))\" cy=\"$((10+(33-y1)*30+15))\" r=\"5\" fill=\"gray\" />"
+	done < <( get_colbuf_data; )
+	echo "</svg>"
+} > colbuf_8k.svg

--- a/icefuzz/tests/colbuf_io_5k.sh
+++ b/icefuzz/tests/colbuf_io_5k.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p colbuf_io_5k.work
+cd colbuf_io_5k.work
+
+glb_pins="20 35 37 44"
+
+pins="
+2 3 4 6 9 10 11 12
+	13 18 19 20 21
+	25 26 27 28 31 32 34 35 36
+	37 38 42 43 44 45 46 47 48
+"
+pins="$( echo $pins )"
+
+for pin in $pins; do
+	pf="colbuf_io_5k_$pin"
+	gpin=$( echo $glb_pins | tr ' ' '\n' | grep -v $pin | sort -R | head -n1; )
+	cat > ${pf}.v <<- EOT
+		module top (input clk, data, output pin);
+			SB_IO #(
+				.PIN_TYPE(6'b 0101_00)
+			) pin_obuf (
+				.PACKAGE_PIN(pin),
+				.OUTPUT_CLK(clk),
+				.D_OUT_0(data)
+			);
+		endmodule
+	EOT
+	echo "set_io pin $pin" > ${pf}.pcf
+	echo "set_io clk $gpin" >> ${pf}.pcf
+	ICEDEV=up5k-sg48 bash ../../icecube.sh ${pf}.v > ${pf}.log 2>&1
+	../../../icebox/icebox_explain.py ${pf}.asc > ${pf}.exp
+	rm -rf ${pf}.tmp
+done

--- a/icefuzz/tests/colbuf_logic_5k.sh
+++ b/icefuzz/tests/colbuf_logic_5k.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p colbuf_logic_5k.work
+cd colbuf_logic_5k.work
+
+glb_pins="20 35 37 44"
+
+for x in {1..5} {7..18} {20..24}; do
+for y in {1..30}; do
+	pf="colbuf_logic_5k_${x}_${y}"
+	gpin=$( echo $glb_pins | tr ' ' '\n' | sort -R | head -n1; )
+	cat > ${pf}.v <<- EOT
+		module top (input c, d, output q);
+			SB_DFF dff (
+				.C(c),
+				.D(d),
+				.Q(q)
+			);
+		endmodule
+	EOT
+	echo "set_location dff $x $y 0" > ${pf}.pcf
+	echo "set_io c $gpin" >> ${pf}.pcf
+	ICEDEV=up5k-sg48 bash ../../icecube.sh ${pf}.v > ${pf}.log 2>&1
+	../../../icebox/icebox_explain.py ${pf}.asc > ${pf}.exp
+	rm -rf ${pf}.tmp
+done; done

--- a/icefuzz/tests/colbuf_ram_5k.sh
+++ b/icefuzz/tests/colbuf_ram_5k.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p colbuf_ram_5k.work
+cd colbuf_ram_5k.work
+
+glb_pins="20 35 37 44"
+
+for x in 6 19; do
+for y in {1..30}; do
+	pf="colbuf_ram_5k_${x}_${y}"
+	gpin=$( echo $glb_pins | tr ' ' '\n' | sort -R | head -n1; )
+	if [ $((y % 2)) == 1 ]; then
+		clkport="WCLK"
+		other_clkport="RCLK"
+	else
+		clkport="RCLK"
+		other_clkport="WCLK"
+	fi
+	cat > ${pf}.v <<- EOT
+		module top (input c, oc, input [1:0] d, output [1:0] q);
+			wire gc;
+			SB_GB_IO #(
+				.PIN_TYPE(6'b 0000_00),
+				.PULLUP(1'b0),
+				.NEG_TRIGGER(1'b0),
+				.IO_STANDARD("SB_LVCMOS")
+			) gbuf (
+				.PACKAGE_PIN(c),
+				.GLOBAL_BUFFER_OUTPUT(gc)
+			);
+			SB_RAM40_4K #(
+				.READ_MODE(3),
+				.WRITE_MODE(3)
+			) ram40 (
+				.WADDR(11'b0),
+				.RADDR(11'b0),
+				.$clkport(gc),
+				.$other_clkport(oc),
+				.RDATA(q),
+				.WDATA(d),
+				.WE(1'b1),
+				.WCLKE(1'b1),
+				.RE(1'b1),
+				.RCLKE(1'b1)
+			);
+		endmodule
+	EOT
+	echo "set_location ram40 $x $((y - (1 - y%2))) 0" > ${pf}.pcf
+	echo "set_io oc 1" >> ${pf}.pcf
+	echo "set_io c $gpin" >> ${pf}.pcf
+	ICEDEV=up5k-sg48 bash ../../icecube.sh ${pf}.v > ${pf}.log 2>&1
+	../../../icebox/icebox_explain.py ${pf}.asc > ${pf}.exp
+	rm -rf ${pf}.tmp
+done; done

--- a/icepack/icepack.cc
+++ b/icepack/icepack.cc
@@ -451,11 +451,12 @@ void FpgaConfig::write_bits(std::ostream &ofs) const
 	write_byte(ofs, crc_value, file_offset, 0x62);
 	write_byte(ofs, crc_value, file_offset, (this->cram_width-1) >> 8);
 	write_byte(ofs, crc_value, file_offset, (this->cram_width-1));
-
-	debug("CRAM: Setting bank height to %d.\n", this->cram_height);
-	write_byte(ofs, crc_value, file_offset, 0x72);
-	write_byte(ofs, crc_value, file_offset, this->cram_height >> 8);
-	write_byte(ofs, crc_value, file_offset, this->cram_height);
+	if(this->device != "5k") {
+		debug("CRAM: Setting bank height to %d.\n", this->cram_height);
+		write_byte(ofs, crc_value, file_offset, 0x72);
+		write_byte(ofs, crc_value, file_offset, this->cram_height >> 8);
+		write_byte(ofs, crc_value, file_offset, this->cram_height);
+	}
 
 	debug("CRAM: Setting bank offset to 0.\n");
 	write_byte(ofs, crc_value, file_offset, 0x82);
@@ -465,10 +466,20 @@ void FpgaConfig::write_bits(std::ostream &ofs) const
 	for (int cram_bank = 0; cram_bank < 4; cram_bank++)
 	{
 		vector<bool> cram_bits;
-		for (int cram_y = 0; cram_y < this->cram_height; cram_y++)
+		int height = this->cram_height;
+		if(this->device == "5k" && ((cram_bank % 2) == 1))
+			height = height / 2 + 8;
+		for (int cram_y = 0; cram_y < height; cram_y++)
 		for (int cram_x = 0; cram_x < this->cram_width; cram_x++)
 			cram_bits.push_back(this->cram[cram_bank][cram_x][cram_y]);
-
+		
+		if(this->device == "5k") {
+			debug("CRAM: Setting bank height to %d.\n", height);
+			write_byte(ofs, crc_value, file_offset, 0x72);
+			write_byte(ofs, crc_value, file_offset, height >> 8);
+			write_byte(ofs, crc_value, file_offset, height);
+		}
+		
 		debug("CRAM: Setting bank %d.\n", cram_bank);
 		write_byte(ofs, crc_value, file_offset, 0x11);
 		write_byte(ofs, crc_value, file_offset, cram_bank);
@@ -491,10 +502,13 @@ void FpgaConfig::write_bits(std::ostream &ofs) const
 
 	if (this->bram_width && this->bram_height)
 	{
-		debug("BRAM: Setting bank width to %d.\n", this->bram_width);
-		write_byte(ofs, crc_value, file_offset, 0x62);
-		write_byte(ofs, crc_value, file_offset, (this->bram_width-1) >> 8);
-		write_byte(ofs, crc_value, file_offset, (this->bram_width-1));
+		if(this->device != "5k") {
+			debug("BRAM: Setting bank width to %d.\n", this->bram_width);
+			write_byte(ofs, crc_value, file_offset, 0x62);
+			write_byte(ofs, crc_value, file_offset, (this->bram_width-1) >> 8);
+			write_byte(ofs, crc_value, file_offset, (this->bram_width-1));
+		}
+
 
 		debug("BRAM: Setting bank height to %d.\n", this->bram_height);
 		write_byte(ofs, crc_value, file_offset, 0x72);
@@ -510,14 +524,25 @@ void FpgaConfig::write_bits(std::ostream &ofs) const
 			for (int offset = 0; offset < this->bram_height; offset += bram_chunk_size)
 			{
 				vector<bool> bram_bits;
+				int width = this->bram_width;
+				if(this->device == "5k" && ((bram_bank % 2) == 1))
+					width = width / 2;
 				for (int bram_y = 0; bram_y < bram_chunk_size; bram_y++)
-				for (int bram_x = 0; bram_x < this->bram_width; bram_x++)
+				for (int bram_x = 0; bram_x < width; bram_x++)
 					bram_bits.push_back(this->bram[bram_bank][bram_x][bram_y+offset]);
 
 				debug("BRAM: Setting bank offset to %d.\n", offset);
 				write_byte(ofs, crc_value, file_offset, 0x82);
 				write_byte(ofs, crc_value, file_offset, offset >> 8);
 				write_byte(ofs, crc_value, file_offset, offset);
+
+				if(this->device == "5k") {
+					debug("BRAM: Setting bank width to %d.\n", width);
+					write_byte(ofs, crc_value, file_offset, 0x62);
+					write_byte(ofs, crc_value, file_offset, (width-1) >> 8);
+					write_byte(ofs, crc_value, file_offset, (width-1));
+				}
+
 
 				debug("BRAM: Writing bank %d data.\n", bram_bank);
 				write_byte(ofs, crc_value, file_offset, 0x01);
@@ -632,18 +657,35 @@ void FpgaConfig::read_ascii(std::istream &ifs)
 				error("Unsupported chip type '%s'.\n", this->device.c_str());
 
 			this->cram.resize(4);
-			for (int i = 0; i < 4; i++) {
-				this->cram[i].resize(this->cram_width);
-				for (int x = 0; x < this->cram_width; x++)
-					this->cram[i][x].resize(this->cram_height);
+			if(this->device == "5k") {
+				for (int i = 0; i < 4; i++) {
+					this->cram[i].resize(this->cram_width);
+					for (int x = 0; x < this->cram_width; x++)
+						this->cram[i][x].resize(((i % 2) == 1) ? (this->cram_height / 2 + 8) : this->cram_height);
+				}
+
+				this->bram.resize(4);
+				for (int i = 0; i < 4; i++) {
+					int width = ((i % 2) == 1) ? (this->bram_width / 2) : this->bram_width;
+					this->bram[i].resize(width);
+					for (int x = 0; x < width; x++)
+						this->bram[i][x].resize(this->bram_height);
+				}
+			} else {
+				for (int i = 0; i < 4; i++) {
+					this->cram[i].resize(this->cram_width);
+					for (int x = 0; x < this->cram_width; x++)
+						this->cram[i][x].resize(this->cram_height);
+				}
+
+				this->bram.resize(4);
+				for (int i = 0; i < 4; i++) {
+					this->bram[i].resize(this->bram_width);
+					for (int x = 0; x < this->bram_width; x++)
+						this->bram[i][x].resize(this->bram_height);
+				}
 			}
 
-			this->bram.resize(4);
-			for (int i = 0; i < 4; i++) {
-				this->bram[i].resize(this->bram_width);
-				for (int x = 0; x < this->bram_width; x++)
-					this->bram[i][x].resize(this->bram_height);
-			}
 
 			got_device = true;
 			continue;

--- a/icepack/icepack.cc
+++ b/icepack/icepack.cc
@@ -661,7 +661,7 @@ void FpgaConfig::read_ascii(std::istream &ifs)
 			continue;
 		}
 
-		if (command == ".io_tile" || command == ".logic_tile" || command == ".ramb_tile" || command == ".ramt_tile")
+		if (command == ".io_tile" || command == ".logic_tile" || command == ".ramb_tile" || command == ".ramt_tile" || command.substr(0, 4) == ".dsp" || command == ".ipconn_tile")
 		{
 			if (!got_device)
 				error("Missing .device statement before %s.\n", command.c_str());
@@ -1165,16 +1165,17 @@ BramIndexConverter::BramIndexConverter(const FpgaConfig *fpga, int tile_x, int t
 	// used for SRAM instead of logic. Therefore the bitstream for the top two
 	// quadrants are half the height of the bottom.
 	if (this->fpga->device == "5k") {
-		top_half = this->tile_y > (chip_height / 3);
+		top_half = this->tile_y > (2 * chip_height / 3);
 	}
 
 	this->bank_num = 0;
 	int y_offset = this->tile_y - 1;
 	if (this->fpga->device == "5k") {
-		if (!top_half) {
+		if (top_half) {
 			this->bank_num |= 1;
+			y_offset = this->tile_y - (2 * chip_height / 3);
 		} else {
-			y_offset = this->tile_y - (chip_height / 3);
+			//y_offset = this->tile_y - (2 * chip_height / 3);
 		}
 	} else if (top_half) {
 		this->bank_num |= 1;


### PR DESCRIPTION
This pull request should continue on from the previous UltraPlus development by fixing various functionality, meaning all of the standard ice40 features are now supported on the 5k and have undergone further testing, including running PicoSoC on the 5k.

Still none of the UltraPlus-specific features are supported (except in icepack) but this will be worked on next.