### PR TITLE
Better emscripten support

### DIFF
--- a/icebram/icebram.cc
+++ b/icebram/icebram.cc
@@ -28,6 +28,10 @@
 #include <fstream>
 #include <iostream>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 using std::map;
 using std::pair;
 using std::vector;
@@ -109,6 +113,18 @@ void help(const char *cmd)
 
 int main(int argc, char **argv)
 {
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+		if (ENVIRONMENT_IS_NODE)
+		{
+			FS.mkdir('/hostcwd');
+			FS.mount(NODEFS, { root: '.' }, '/hostcwd');
+			FS.mkdir('/hostfs');
+			FS.mount(NODEFS, { root: '/' }, '/hostfs');
+		}
+	);
+#endif
+
 	bool verbose = false;
 	bool generate = false;
 

--- a/icemulti/icemulti.cc
+++ b/icemulti/icemulti.cc
@@ -24,6 +24,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 #define log(...) fprintf(stderr, __VA_ARGS__);
 #define error(...) do { fprintf(stderr, "%s: ", program_short_name); fprintf(stderr, __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
 
@@ -178,6 +182,18 @@ void usage()
 
 int main(int argc, char **argv)
 {
+#ifdef __EMSCRIPTEN__
+    EM_ASM(
+        if (ENVIRONMENT_IS_NODE)
+        {
+            FS.mkdir('/hostcwd');
+            FS.mount(NODEFS, { root: '.' }, '/hostcwd');
+            FS.mkdir('/hostfs');
+            FS.mount(NODEFS, { root: '/' }, '/hostfs');
+        }
+    );
+#endif
+
     int c;
     char *endptr = NULL;
     bool coldboot = false;

--- a/icepack/icepack.cc
+++ b/icepack/icepack.cc
@@ -34,6 +34,10 @@
 #include <stdio.h>
 #include <stdarg.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 #ifdef _WIN32
 #define __PRETTY_FUNCTION__ __FUNCTION__
 #endif
@@ -1338,6 +1342,18 @@ void usage()
 
 int main(int argc, char **argv)
 {
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+		if (ENVIRONMENT_IS_NODE)
+		{
+			FS.mkdir('/hostcwd');
+			FS.mount(NODEFS, { root: '.' }, '/hostcwd');
+			FS.mkdir('/hostfs');
+			FS.mount(NODEFS, { root: '/' }, '/hostfs');
+		}
+	);
+#endif
+
 	vector<string> parameters;
 	bool unpack_mode = false;
 	bool nosleep_mode = false;

--- a/icepll/icepll.cc
+++ b/icepll/icepll.cc
@@ -20,6 +20,10 @@
 #include <string.h>
 #include <math.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 const char *binstr(int v, int n)
 {
 	static char buffer[16];
@@ -63,6 +67,18 @@ void help(const char *cmd)
 
 int main(int argc, char **argv)
 {
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+		if (ENVIRONMENT_IS_NODE)
+		{
+			FS.mkdir('/hostcwd');
+			FS.mount(NODEFS, { root: '.' }, '/hostcwd');
+			FS.mkdir('/hostfs');
+			FS.mount(NODEFS, { root: '/' }, '/hostfs');
+		}
+	);
+#endif
+
 	double f_pllin = 12;
 	double f_pllout = 60;
 	bool simple_feedback = true;

--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -33,6 +33,10 @@
 #include <map>
 #include <set>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 // add this number of ns as estimate for clock distribution mismatch
 #define GLOBAL_CLK_DIST_JITTER 0.1
 
@@ -2223,6 +2227,18 @@ void help(const char *cmd)
 
 int main(int argc, char **argv)
 {
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+		if (ENVIRONMENT_IS_NODE)
+		{
+			FS.mkdir('/hostcwd');
+			FS.mount(NODEFS, { root: '.' }, '/hostcwd');
+			FS.mkdir('/hostfs');
+			FS.mount(NODEFS, { root: '/' }, '/hostfs');
+		}
+	);
+#endif
+
 	bool listnets = false;
 	bool print_timing = false;
 	bool interior_timing = false;


### PR DESCRIPTION
The first commit makes the following changes:
* Includes config.mk after defining SUBDIRS so that config.mk can override it (so that emscripten doesn't build iceprog)
* Adds an "EMCC" flag to build with emscripten.
* Allows the debug metadata level to be controlled because emscripten does not support `-ggdb`.
* Adds `$(EXE)` in various places
* Adds a hack to the icetime makefile so that it copies over the chipdb files and embeds them into the resulting javascript

The second commit modifies all binaries to mount emscripten's NODEFS on `/x` if the resulting javascript is run under nodejs. This is useful for testing so that the resulting javascript can interact with files on the host filesystem. By default, emscripten-compiled output can only access its in-memory virtual filesystem. It also isn't possible to mount additional emscripten filesystems over the root, so as a compromise NODEFS is mounted on `/x`. After this change, it is possible to run commands like
```
$ nodejs icepll/icepll.js -f /x/test.v
$ nodejs icepack/icepack.js /x/in.asc /x/out.bin
```
This will interact with files `test.v`, `in.asc`, and `out.bin` in the current working directory.