### PR TITLE
Add flash unprotect sequence to iceprog

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -312,6 +312,21 @@ static void flash_write_enable()
 	set_gpio(1, 0);
 }
 
+static void flash_unprotect()
+{
+	if (verbose)
+		fprintf(stderr, "unprotect sectors..\n");
+
+	/* Global Unprotect */
+	uint8_t data3[2] = { FC_WSR1, 0x00 };
+	set_gpio(0, 0);
+	xfer_spi(data3, 2);
+	set_gpio(1, 0);
+
+	/* After global unprotect, need to re-enable writes */
+	flash_write_enable();
+}
+
 static void flash_bulk_erase()
 {
 	fprintf(stderr, "bulk erase..\n");
@@ -869,6 +884,7 @@ int main(int argc, char **argv)
 				if (bulk_erase)
 				{
 					flash_write_enable();
+					flash_unprotect();
 					flash_bulk_erase();
 					flash_wait();
 				}
@@ -881,6 +897,7 @@ int main(int argc, char **argv)
 
 					for (int addr = begin_addr; addr < end_addr; addr += 0x10000) {
 						flash_write_enable();
+						flash_unprotect();
 						flash_64kB_sector_erase(addr);
 						flash_wait();
 					}
@@ -898,6 +915,7 @@ int main(int argc, char **argv)
 					if (rc <= 0)
 						break;
 					flash_write_enable();
+					flash_unprotect();
 					flash_prog(rw_offset + addr, buffer, rc);
 					flash_wait();
 				}


### PR DESCRIPTION
I have a custom board with an AT25DF041B flash chip.  Its sectors are write-protected by default, and this sequence is required to unprotect it.  I don't think this should affect other chips like the W25Q128JV, but this feature could be hidden behind a command line option if there's any concern about that.