### PR TITLE
icebox_hlc2asc: Allow truth tables to be specified as init string.

### DIFF
--- a/icebox/icebox_hlc2asc.py
+++ b/icebox/icebox_hlc2asc.py
@@ -838,8 +838,19 @@ class LogicCell:
         if fields[0] == 'lut' and len(fields) == 2 and self.lut_bits is None:
             self.lut_bits = fields[1]
         elif fields[0] == 'out' and len(fields) >= 3 and fields[1] == '=':
-            self.lut_bits = logic_expression_to_lut(
-                ' '.join(fields[2:]), ('in_0', 'in_1', 'in_2', 'in_3'))
+            m = re.match("([0-9]+)'b([01]+)", fields[2])
+            if m:
+                lut_bits = m.group(2)
+                if len(lut_bits) != int(m.group(1)):
+                    raise ParseError
+                m = len(lut_bits)
+                if m < 16:
+                    lut_bits = (16-m) * "0" + lut_bits
+                # Verilog 16'bXXXX is MSB first but the bitstream wants LSB.
+                self.lut_bits = lut_bits[::-1]
+            else:
+                self.lut_bits = logic_expression_to_lut(
+                    ' '.join(fields[2:]), ('in_0', 'in_1', 'in_2', 'in_3'))
         elif fields == ['enable_carry']:
             self.seq_bits[0] = '1'
         elif fields == ['enable_dff']:


### PR DESCRIPTION
Patch originally created by @jhol.
Examples;
```hlc
lutff_5 {
    # - Parameters -------
    # LUT_INIT = 0111111110000000

    local_g3_4 -> lutff_5/in_0
    local_g0_6 -> lutff_5/in_1
    local_g2_7 -> lutff_5/in_2
    lutff_5/out -> span4_x3_g12_11
    lutff_5/out -> local_g3_5 -> lutff_5/in_3
    out = 16'b0111111110000000
    enable_dff
}
```

```hlc
lutff_4 {
    local_g3_5 -> lutff_4/in_2
    lutff_4/out -> span12_y12_g6_0
    out = 16'b0000000000010000
    enable_dff
}
```

```hlc
lutff_2 {
    # - Parameters -------
    # LUT_INIT = 01

    lutff_2/out -> span12_y12_g8_0
    lutff_2/out -> span12_x2_g14_0
    lutff_2/out -> local_g0_2 -> lutff_2/in_0
    out = 2'b01
    enable_dff
}
```