### PR TITLE
Fix spelling and io_X/GLOBAL_OUTPUT_NETWORK

### DIFF
--- a/icebox/icebox_hlc2asc.py
+++ b/icebox/icebox_hlc2asc.py
@@ -1006,7 +1006,9 @@ class IOBlock:
             self.enable_input = True
         elif fields == ['disable_pull_up'] and not self.disable_pull_up:
             self.disable_pull_up = True
-        elif fields[0] == 'GLOBAL_BUFFER_OUTPUT' and fields[1] == '->' \
+        elif fields[0] in ('GLOBAL_BUFFER_OUTPUT',
+                           'io_%d/GLOBAL_BUFFER_OUTPUT' % self.index) \
+                and fields[1] == '->' \
                 and fields[2].startswith('glb_netwk_'):
             if GLB_NETWK_EXTERNAL_BLOCKS[int(fields[2][10:])] \
                     != (self.tile.x, self.tile.y, self.index):

--- a/icebox/icebox_hlc2asc.py
+++ b/icebox/icebox_hlc2asc.py
@@ -293,7 +293,7 @@ def revert_to_fabout(x, y, net):
         for i, xy in enumerate(GLB_NETWK_INTERNAL_TILES):
             if net == 'glb_netwk_%d' % i and (x, y) == xy:
                 return 'fabout'
-        raise ParseError("{} is a global netowrk, but not at an expectd location {} {}".format(net, x, y))
+        raise ParseError("{} is a global network, but not at an expected location {} {}".format(net, x, y))
 
     return net
 
@@ -956,7 +956,7 @@ class IOTile(Tile):
         if fields == ['io_1'] and self.blocks[1] is None:
             self.blocks[1] = IOBlock(self, 1)
             return self.blocks[1]
-        raise ParseError("Unepxected new block in {}".format(type(self).__name__))
+        raise ParseError("Unexpected new block in {}".format(type(self).__name__))
 
 class IOBlock:
     def __init__(self, tile, index):


### PR DESCRIPTION
Every other source inside an IO tile supports the `io_X` prefix.