### PR TITLE
icebox_vlog: Fix constant LUT output.

### DIFF
--- a/icebox/icebox_vlog.py
+++ b/icebox/icebox_vlog.py
@@ -842,9 +842,9 @@ for lut in luts_queue:
     else:
         always_stmts.append("/* FF %2d %2d %2d */ assign %s = %s;" % (lut[0], lut[1], lut[2], net_out, net_lout))
     if not "1" in lut_bits:
-        const_assigns.append([net_out, "1'b0"])
+        const_assigns.append([net_lout, "/* LUT   %2d %2d %2d */ 1'b0" % (lut[0], lut[1], lut[2])])
     elif not "0" in lut_bits:
-        const_assigns.append([net_out, "1'b1"])
+        const_assigns.append([net_lout, "/* LUT   %2d %2d %2d */ 1'b1" % (lut[0], lut[1], lut[2])])
     else:
         def make_lut_expr(bits, sigs):
             if not sigs:


### PR DESCRIPTION
Previously you would end up with an error;
`iceram_bit.v:1889: error: reg n26; cannot be driven by primitives or continuous assignment.`
