### PR TITLE
icebox_hlc2asc: fix _lut_ keyword parsing

### DIFF
--- a/icebox/icebox_hlc2asc.py
+++ b/icebox/icebox_hlc2asc.py
@@ -865,7 +865,7 @@ class LogicCell:
         self.seq_bits = ['0'] * 4
 
     def read(self, fields):
-        if fields[0] == 'lut' and len(fields) == 2 and self.lut_bits is None:
+        if fields[0] == 'lut' and len(fields) == 2:
             self.lut_bits = fields[1]
         elif fields[0] == 'out' and len(fields) >= 3 and fields[1] == '=':
             m = re.match("([0-9]+)'b([01]+)", fields[2])


### PR DESCRIPTION
'self.lut_bits is None' was always false as it is set to 16*[0]. The _lut_ keyword is used by asc2hlc, so when converting asc->hlc->asc the lut_bits were all zeros.