### PR TITLE
robustness and debugability improvement work

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -40,6 +40,19 @@
 // MPSSE / FTDI definitions
 // ---------------------------------------------------------
 
+/* FTDI bank pinout typically used for iCE dev boards
+ * BUS IO | Signal | Control
+ * -------+--------+--------------
+ * xDBUS0 |    SCK | MPSSE
+ * xDBUS1 |   MOSI | MPSSE
+ * xDBUS2 |   MISO | MPSSE
+ * xDBUS3 |     nc |
+ * xDBUS4 |     CS | GPIO
+ * xDBUS5 |     nc |
+ * xDBUS6 |  CDONE | GPIO
+ * xDBUS7 | CRESET | GPIO
+ */
+
 static struct ftdi_context ftdic;
 static bool ftdic_open = false;
 static bool verbose = false;

--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -450,16 +450,16 @@ static void flash_disable_protection()
 {
 	fprintf(stderr, "disable flash protection...\n");
 
-	//WRSR 0x00
-	uint8_t data[2] = { 0x01, 0x00 };
+	// Write Status Register 1 <- 0x00
+	uint8_t data[2] = { FC_WSR1, 0x00 };
 	flash_chip_select(true);
 	xfer_spi(data, 2);
 	flash_chip_select(false);
 	
 	flash_wait();
 	
-	//RDSR
-	data[0] = 0x5;
+	// Read Status Register 1
+	data[0] = FC_RSR1;
 
 	flash_chip_select(true);
 	xfer_spi(data, 2);


### PR DESCRIPTION
I was having trouble with a AT25XE021A chip. So I went down the path of adding more debugging capabilities to the iceprog codebase and modifying functions to make them more robust in cases of a misbehaving FLASH chip. The most likely issue in my particular case was reading beyond the reported length of the JEDEC ID. This obviously is strange and it is not clear why a FLASH chip would ever have an issue with that.
The changes included in this pull request effectively solve my issue but as a sideffect add more verbose output that will help debugging a problems when if we run into another unhappy FLASH chip. :)