### PR TITLE
Replace the 0xFF command with FC_EQPI.

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -175,6 +175,7 @@ enum flash_cmd {
 	FC_EPR = 0x7A, /* Erase / Program Resume */
 	FC_PD = 0xB9, /* Power-down */
 	FC_QPI = 0x38, /* Enter QPI mode */
+	FC_EQPI = 0xFF, /* Exit QPI mode */
 	FC_ERESET = 0x66, /* Enable Reset */
 	FC_RESET = 0x99, /* Reset Device */
 };
@@ -394,11 +395,11 @@ static void flash_read_id()
 static void flash_reset()
 {
 	flash_chip_select();
-	xfer_spi_bits(0xFF, 8);
+	xfer_spi_bits(FC_EQPI, 8);
 	flash_chip_deselect();
 
 	flash_chip_select();
-	xfer_spi_bits(0xFF, 2);
+	xfer_spi_bits(FC_EQPI, 2);
 	flash_chip_deselect();
 }
 


### PR DESCRIPTION
FC_EQPI did exist as a command before. There might be a good reason why it was replaced with the 0xFF but it is a documented command in the [W25Q128JV-DTR](http://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf) datasheet so let's bring it back. ;-)