### PR TITLE
Fix compile warning in icetime.cc

### DIFF
--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -1320,7 +1320,7 @@ std::string ecnetname_to_vlog(std::string ec_name)
 		} else {
 			return ec_name;
 		}
-	} catch(std::invalid_argument e) { // Not numeric and stoi throws exception
+	} catch(std::invalid_argument &e) { // Not numeric and stoi throws exception
 		return ec_name;
 	}
 


### PR DESCRIPTION
icetime.cc: In function ‘std::__cxx11::string ecnetname_to_vlog(std::__cxx11::string)’:
icetime.cc:1323:32: warning: catching polymorphic type ‘class std::invalid_argument’ by value [-Wcatch-value=]
  } catch(std::invalid_argument e) { // Not numeric and stoi throws exception