### PR TITLE
add boost dependencie for fedora

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@ On Fedora 24 the following command installs all prerequisites:
 sudo dnf install make automake gcc gcc-c++ kernel-devel clang bison \
                  flex readline-devel gawk tcl-devel libffi-devel git mercurial \
                  graphviz python-xdot pkgconfig python python3 libftdi-devel \
-                 qt5-devel python3-devel boost-devel
+                 qt5-devel python3-devel boost-devel boost-python3-devel
 </pre>
 
 <p>


### PR DESCRIPTION
Found out the dependencie for boost wasn't complete for Fedora