### PR TITLE
Fix warnings: 'may be used uninitialized in this function'

### DIFF
--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -1087,7 +1087,7 @@ struct TimingAnalysis
 				fprintf(frpt, "Resolvable net names on path:\n");
 
 				std::string last_net;
-				double first_time, last_time;
+				double first_time = 0.0, last_time = 0.0;
 
 				for (int i = int(sym_list.size())-1; i >= 0; i--) {
 					if (last_net != sym_list[i].second) {


### PR DESCRIPTION
```
icetime.cc: In member function ‘double TimingAnalysis::report(std::__cxx11::string)’:
icetime.cc:1095:15: warning: ‘last_time’ may be used uninitialized in this function [-Wmaybe-uninitialized]
        fprintf(frpt, "%10.3f ns ..%7.3f ns %s\n", first_time, last_time, last_net.c_str());
        ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
icetime.cc:1095:15: warning: ‘first_time’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```

The variables are not actually being used uninitialized.
Just silence the compiler warning.