### PR TITLE
Option for icepack to skip initializing BRAM (tested for ice40hx8k) with "-n"

### DIFF
--- a/icepack/icepack.cc
+++ b/icepack/icepack.cc
@@ -112,6 +112,7 @@ struct FpgaConfig
 	// bram[BANK][X][Y]
 	int bram_width, bram_height;
 	vector<vector<vector<bool>>> bram;
+        bool skip_bram_initialization;
 
 	// data before preamble
 	vector<uint8_t> initblop;
@@ -579,18 +580,20 @@ void FpgaConfig::write_bits(std::ostream &ofs) const
 				}
 
 
-				debug("BRAM: Writing bank %d data.\n", bram_bank);
-				write_byte(ofs, crc_value, file_offset, 0x01);
-				write_byte(ofs, crc_value, file_offset, 0x03);
-				for (int i = 0; i < int(bram_bits.size()); i += 8) {
-					uint8_t byte = 0;
-					for (int j = 0; j < 8; j++)
-						byte = (byte << 1) | (bram_bits[i+j] ? 1 : 0);
-					write_byte(ofs, crc_value, file_offset, byte);
-				}
+                                if (!this->skip_bram_initialization) {
+                                    debug("BRAM: Writing bank %d data.\n", bram_bank);
+                                    write_byte(ofs, crc_value, file_offset, 0x01);
+                                    write_byte(ofs, crc_value, file_offset, 0x03);
+                                    for (int i = 0; i < int(bram_bits.size()); i += 8) {
+                                            uint8_t byte = 0;
+                                            for (int j = 0; j < 8; j++)
+                                                    byte = (byte << 1) | (bram_bits[i+j] ? 1 : 0);
+                                            write_byte(ofs, crc_value, file_offset, byte);
+                                    }
 
-				write_byte(ofs, crc_value, file_offset, 0x00);
-				write_byte(ofs, crc_value, file_offset, 0x00);
+                                    write_byte(ofs, crc_value, file_offset, 0x00);
+                                    write_byte(ofs, crc_value, file_offset, 0x00);
+                                }
 			}
 		}
 	}
@@ -1348,6 +1351,9 @@ void usage()
 	log("    -B0, -B1, -B2, -B3\n");
 	log("        only include the specified bank in the netpbm file\n");
 	log("\n");
+	log("    -n\n");
+	log("        skip initializing BRAM\n");
+	log("\n");
 	exit(1);
 }
 
@@ -1372,6 +1378,7 @@ int main(int argc, char **argv)
 	bool netpbm_bram = false;
 	bool netpbm_fill_tiles = false;
 	bool netpbm_checkerboard = false;
+        bool skip_bram_initialization = false;
 	int netpbm_banknum = -1;
 	int checkerboard_m = 1;
 
@@ -1406,6 +1413,8 @@ int main(int argc, char **argv)
 					nosleep_mode = true;
 				} else if (arg[i] == 'v') {
 					log_level++;
+				} else if (arg[i] == 'n') {
+					skip_bram_initialization = true;
 				} else
 					usage();
 			continue;
@@ -1442,6 +1451,8 @@ int main(int argc, char **argv)
 		usage();
 
 	FpgaConfig fpga_config;
+        
+        fpga_config.skip_bram_initialization = skip_bram_initialization;
 
 	if (unpack_mode) {
 		fpga_config.read_bits(*isp);


### PR DESCRIPTION
This is required for some experiments, such as evaluating the SRAM-based BRAM for their properties as a "Physical Unclonable Function" (PUF). In our case this is used for educational purposes, where we try to get away from the vendor software, which supports this feature.

Per default icepack initializes the BRAM with all 0.

Let me know on any doubts you might have.