### PR TITLE
icepll: In quiet mode don't print info about target file name

### DIFF
--- a/icepll/icepll.cc
+++ b/icepll/icepll.cc
@@ -314,7 +314,8 @@ int main(int argc, char **argv)
 
 		fclose(f);
 
-		printf("PLL configuration written to: %s\n", filename);
+		if (!quiet)
+			printf("PLL configuration written to: %s\n", filename);
 	}
 
 	return 0;


### PR DESCRIPTION
In quiet mode do not print information about the target file.
This way we can really be quiet when writing to a file.
That avoids cluttering project's build logs with redundant information, for example.