### PR TITLE
iceprog: Better reset of flash

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -195,12 +195,10 @@ static void flash_read_id()
 
 static void flash_reset()
 {
-	flash_chip_select();
-	mpsse_xfer_spi_bits(0xFF, 8);
-	flash_chip_deselect();
+	uint8_t data[8] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
 	flash_chip_select();
-	mpsse_xfer_spi_bits(0xFF, 2);
+	mpsse_xfer_spi(data, 8);
 	flash_chip_deselect();
 }
 


### PR DESCRIPTION
If the flash was in a 'weird' mode (like CRM, QPI, ...), sending
a continuous stream of 0xff should take it out of it.

It looks like the previous code was trying to do that, but
was only transferring 8 bits and then 2 bits which is way
too short.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>