### PR TITLE
Use -MMD instead of -MD, preventing system headers from showing up in .d files

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -18,8 +18,8 @@ endif
 WARN_LEVEL ?= all
 
 LDLIBS = -lm -lstdc++
-CFLAGS += -MD -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(C_STD) -I$(PREFIX)/include
-CXXFLAGS += -MD -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(CXX_STD) -I$(PREFIX)/include
+CFLAGS += -MMD -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(C_STD) -I$(PREFIX)/include
+CXXFLAGS += -MMD -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(CXX_STD) -I$(PREFIX)/include
 
 DESTDIR ?=
 CHIPDB_SUBDIR ?= icebox

--- a/docs/notes_osx.html
+++ b/docs/notes_osx.html
@@ -32,7 +32,7 @@ Note that Mac Ports installs to /opt instead of /usr, so change the first two li
 
 <pre style="padding-left: 3em">
 LDLIBS = -L/usr/local/lib -L/opt/local/lib -lftdi -lm
-CFLAGS = -MD -O0 -ggdb -Wall -std=c99 -I/usr/local/include -I/opt/local/include/
+CFLAGS = -MMD -O0 -ggdb -Wall -std=c99 -I/usr/local/include -I/opt/local/include/
 </pre>
 
 <p>


### PR DESCRIPTION
Tried to do a `git pull; make` on a fairly stale, previously-built clone of `icestorm`. A minor change in my system headers prevented the compile from succeeding; `.d` files from the old build referenced system headers that had been moved/changed. Using `-MMD` instead of `-MD` to generate the `.d` files will exclude system headers, preventing this problem.