### PR TITLE
Use -MP to eliminate one way that -MD can fatally confuse make

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -19,8 +19,8 @@ endif
 WARN_LEVEL ?= all
 
 LDLIBS = -lm -lstdc++
-CFLAGS += -MD -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(C_STD) -I$(PREFIX)/include
-CXXFLAGS += -MD -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(CXX_STD) -I$(PREFIX)/include
+CFLAGS += -MD -MP -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(C_STD) -I$(PREFIX)/include
+CXXFLAGS += -MD -MP -O$(OPT_LEVEL) $(DBG_LEVEL) -W$(WARN_LEVEL) -std=$(CXX_STD) -I$(PREFIX)/include
 
 DESTDIR ?=
 CHIPDB_SUBDIR ?= $(PROGRAM_PREFIX)icebox


### PR DESCRIPTION
This attempts to solve the same problem as #240, but is a much better approach. `-MP` causes the compiler to emit dummy targets for every included header file, so that Make won't throw an error if a header disappears. Instead, it will (as it should) simply rebuild the affected files. These dummy targets are ignored in the presence of real targets for e.g. generated headers.

(Sorry if it seems like I'm fighting for a weirdly specific hill. It's just that I remembered about `-MP` while working on an unrelated project and was instantly reminded of #240.)
