### PR TITLE
icetime: avoid string + int Clang warning

### DIFF
--- a/icetime/iceutil.cc
+++ b/icetime/iceutil.cc
@@ -155,7 +155,7 @@ std::string find_chipdb(std::string config_device)
 #else
 		homepath += getenv("HOME");
 #endif
-		homepath += std::string(PREFIX + 1) + "/" CHIPDB_SUBDIR "/chipdb-" + config_device + ".txt";
+		homepath += std::string(&PREFIX[1]) + "/" CHIPDB_SUBDIR "/chipdb-" + config_device + ".txt";
 		if (verbose)
 			fprintf(stderr, "Looking for chipdb '%s' at %s\n", config_device.c_str(), homepath.c_str());
 		if (file_test_open(homepath))


### PR DESCRIPTION
Clang warns that "adding 'int' to a string does not append to the string".
Although a false positive it's trivially avoided by using the array index
equivalent &PREFIX[1].