### PR TITLE
icebox: Add support for the bit 1 of SHIFTREG_DIV_MODE

### DIFF
--- a/icebox/icebox.py
+++ b/icebox/icebox.py
@@ -1954,7 +1954,8 @@ pllinfo_db = {
         "PLLOUT_SELECT_B_1":    (12, 31, "PLLCONFIG_3"),
 
         # Numeric Parameters
-        "SHIFTREG_DIV_MODE":    (12, 31, "PLLCONFIG_4"),
+        "SHIFTREG_DIV_MODE_0":  (12, 31, "PLLCONFIG_4"),
+        "SHIFTREG_DIV_MODE_1":  (14, 31, "PLLCONFIG_6"),
         "FDA_FEEDBACK_0":       (12, 31, "PLLCONFIG_9"),
         "FDA_FEEDBACK_1":       (13, 31, "PLLCONFIG_1"),
         "FDA_FEEDBACK_2":       (13, 31, "PLLCONFIG_2"),


### PR DESCRIPTION
This allows selection of the div-by-5 mode of the PLL.
This bit can't be fuzzed because it's not supported by the lattice
tools at all ...

It's only been tested on the UP5k, the other positions are educated
guesses. TBH it might not even exist on older FPGA variants HX/LP ...

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>