### PR TITLE
Ft2232d fixes

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -872,6 +872,28 @@ int main(int argc, char **argv)
 
 		fprintf(stderr, "cdone: %s\n", get_cdone() ? "high" : "low");
 
+		sram_chip_deselect();
+		usleep(100);
+		sram_chip_select();
+
+		uint8_t sig[] = { 0x7e, 0xaa, 0x99, 0x7e, // key
+				  0x01, 0x09,		  // command
+				  0, 0, 0, 0 };		  // room for result
+		mpsse_xfer_spi(sig, sizeof sig);
+		fprintf(stderr, "Signature read: ");
+		for (int i = 0; i < 4; i++)
+			fprintf(stderr, "0x%02x ", sig[i + 6]);
+		fprintf(stderr, "\n");
+
+		if (sig[6] == 0xff && sig[7] == 0xff &&
+		    sig[8] == 0xff && sig[9] == 0xff)
+			fprintf(stderr,
+				"WARNING: Signature is 0xFFFFFFFF. "
+				"Are CRAM jumpers set correctly?\n");
+
+		sram_chip_deselect();
+		usleep(100);
+		sram_chip_select();
 
 		// ---------------------------------------------------------
 		// Program

--- a/iceprog/mpsse.c
+++ b/iceprog/mpsse.c
@@ -338,8 +338,11 @@ void mpsse_init(int ifnum, const char *devstr, bool slow_clock)
 		mpsse_error(2);
 	}
 
-	// enable clock divide by 5
-	mpsse_send_byte(MC_TCK_D5);
+	// enable clock divide by 5 for USB-HS chips
+	if (mpsse_ftdic.type == TYPE_2232H ||
+	    mpsse_ftdic.type == TYPE_4232H ||
+	    mpsse_ftdic.type == TYPE_232H)
+		mpsse_send_byte(MC_TCK_D5);
 
 	if (slow_clock) {
 		// set 50 kHz clock


### PR DESCRIPTION
When debugging a custom iCE40UP5K board that uses an FT2232D chip to configure the flash/FPGA, I noticed a few things in iceprog that don't work with the "D" variant.

First ist, the "divide clock by 5" command is (obviously) only available on the HS-USB chips. Issuing it on an FT2232D causes the entire sequence to go wrong. E.g. reading the flash signature bytes returns two additional 0xFF bytes before the actual signature then. Since the command is only meant to make the USB-HS chips (FT2232H etc.) compatible with the FT2232D, the solution is to simply omit it for the latter.

Further, the commands 0x8E/0x8F used in the mpsse_send_dummy_{bits,bytes} functions are also only available on the USB-HS chips. These commands are used to send the 49 dummy bits required by the iCE40 documentation once CDONE has been asserted at the end of configuration. However, since only "at least 49 bits" are required, a generic way to issue them is to just send full 7 dummy bytes instead. This can be done using mpsse_send_spi which is also available on the FT2232D.

While analyzing all this, I found the Radiant programmer issues a command during startup that retrieves a kind of signature ID from the FPGA. If this command yields 0xFFFFFFFF, this is a strong indication the board has not been correctly jumpered for SRAM operation, so I added it to iceprog, too.