### PR TITLE
Make icebram deterministic

### DIFF
--- a/icebram/icebram.cc
+++ b/icebram/icebram.cc
@@ -106,7 +106,7 @@ void help(const char *cmd)
 	printf("        use the same file as <from_hexfile> later.\n");
 	printf("\n");
 	printf("    -s <seed>\n");
-	printf("        seed random generator with fixed value.\n");
+	printf("        seed random generator with the given value.\n");
 	printf("\n");
 	printf("    -v\n");
 	printf("        verbose output\n");
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
 	bool verbose = false;
 	bool generate = false;
 	bool seed = false;
-	uint32_t seed_nr = getpid();
+	uint32_t seed_nr = 0;
 
 	int opt;
 	while ((opt = getopt(argc, argv, "vgs:")) != -1)


### PR DESCRIPTION
The direct cause of this PR is WASI support. WASI doesn't have `getpid`. However, it does have `getrandom`, so using that is an alternative.

That being said, the discovery that `icebram` will produce nondeterministic result was an unexpected one for me, and relying on PID specifically seems to be the worst of both options: it breaks reproducible builds, but also it does not guarantee unique values, since PIDs can roll over and it doesn't take very long.

I would prefer to have deterministic `icebram`, so I went with that option in the PR.