### PR TITLE
Added example for ice4pi board

### DIFF
--- a/examples/ice4pi/.gitignore
+++ b/examples/ice4pi/.gitignore
@@ -1,0 +1,7 @@
+*
+!.gitignore
+!example.v
+!ice4pi.pcf
+!Makefile
+!README
+!ice4pi_prog

--- a/examples/ice4pi/Makefile
+++ b/examples/ice4pi/Makefile
@@ -1,0 +1,11 @@
+example.bin: example.v ice4pi.pcf
+	yosys example.ys
+	arachne-pnr -p ice4pi.pcf example.blif -o example.txt
+	icebox_explain example.txt > example.ex
+	icepack example.txt example.bin
+
+load: example.bin
+	./ice4pi_prog example.bin
+
+clean:
+	rm -f example.blif example.txt example.ex example.bin

--- a/examples/ice4pi/README
+++ b/examples/ice4pi/README
@@ -1,0 +1,26 @@
+Assuming you are running on a Raspberry Pi 2-4 or Zero (tested with bullseye):
+
+1. Install all necessary packages to synthesize rot.v and build bit image (rot.bin) for the ice4pi:
+
+ sudo apt-get install yosys fpga-icestorm arachne-pnr flashrom
+ sudo apt-get install spi-tools
+ make
+
+2. Make sure your Pi has SPI enabled (e.g. use raspi-config)
+
+3. Load the example.bin file to the shield:
+
+ sudo make load
+
+---
+
+4. Validate spi loopback:
+
+
+echo -n 0123456789ABCDEF | spi-pipe -d /dev/spidev0.1 -s 10000000
+
+You should get back 
+F0123456789ABCDE
+
+(F may be NUL if this is your first call)
+

--- a/examples/ice4pi/example.v
+++ b/examples/ice4pi/example.v
@@ -1,0 +1,33 @@
+module top(input clk,
+           output [4:0] led,
+           input [7:0] pmod,
+           //spi interface
+           output spi_miso,
+           input spi_mosi,
+           input spi_clk,
+           input spi_cs_n);
+ 
+   //parameter SPI_MODE = 1; // CPOL = 0, CPHA = 1
+
+   reg [8:0] fifo = 8'd0;
+   reg [2:0] counter = 0;
+
+   always @ (negedge spi_clk)
+   begin
+      fifo <= {fifo[7:0],spi_mosi}; // loopback fifo
+      if(counter < 4'd7) begin
+            counter <= counter + 1;
+      end
+      else begin
+          counter <= 0;
+          led <={fifo[3:0],spi_mosi};
+      end
+   end
+
+   always @ (posedge spi_clk)
+   begin
+      spi_miso<=fifo[7]; // loopback
+      //spi_miso<=pmod[counter]; //logic analyzer
+   end
+
+endmodule // top

--- a/examples/ice4pi/ice4pi.pcf
+++ b/examples/ice4pi/ice4pi.pcf
@@ -1,0 +1,27 @@
+#12 MHz oscillator
+set_io clk 21
+
+#Raspberry Pi 40 pin connector
+set_io spi_miso 68 # 115
+set_io spi_mosi 67 # 114
+set_io spi_clk 70 # 112
+set_io spi_cs_n  113 # 128 # /ce1
+
+
+#LEDs
+set_io led[0] 99
+set_io led[1] 98
+set_io led[2] 97
+set_io led[3] 96
+set_io led[4] 95
+
+
+#PMOD
+set_io pmod[0] 78
+set_io pmod[1] 79
+set_io pmod[2] 80
+set_io pmod[3] 81
+set_io pmod[4] 87
+set_io pmod[5] 88
+set_io pmod[6] 90
+set_io pmod[7] 91

--- a/examples/ice4pi/ice4pi_prog
+++ b/examples/ice4pi/ice4pi_prog
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo 24 > /sys/class/gpio/export || true
+echo out > /sys/class/gpio/gpio24/direction
+echo 1 >/sys/class/gpio/gpio24/value
+sleep 1
+echo 0 >/sys/class/gpio/gpio24/value
+
+tr '\0' '\377' < /dev/zero | dd bs=1M count=4 of=image iflag=fullblock
+dd if=${1} conv=notrunc of=image
+flashrom -p linux_spi:dev=/dev/spidev0.0,spispeed=20000 -w image
+echo 1 >/sys/class/gpio/gpio24/value


### PR DESCRIPTION
This is example for ice4pi Raspberry Pi shield. The example is of a simple SPI slave device that can be built on a Raspberry Pi running Debian Bullseye (current stable version), loaded to the shield and tested with the spi-pipe tool.