### PR TITLE
continue 4bc68c9 Fix icebox_vlog for up5k

### DIFF
--- a/icebox/icebox_vlog.py
+++ b/icebox/icebox_vlog.py
@@ -534,7 +534,10 @@ for pllid in ic.pll_list():
         else:
             text_func.append("  .PLLOUT_SELECT_PORTA(\"%s\")," % get_pll_outsel(pllinfo, "PLLOUT_SELECT_A"))
             text_func.append("  .PLLOUT_SELECT_PORTB(\"%s\")," % get_pll_outsel(pllinfo, "PLLOUT_SELECT_B"))
-        text_func.append("  .SHIFTREG_DIV_MODE(1'b%s)," % get_pll_bit(pllinfo, "SHIFTREG_DIV_MODE"))
+            if ic.device == "5k":
+                text_func.append("  .SHIFTREG_DIV_MODE(2'b%s)," % get_pll_bits(pllinfo, "SHIFTREG_DIV_MODE", 2))
+            else:
+                text_func.append("  .SHIFTREG_DIV_MODE(1'b%s)," % get_pll_bit(pllinfo, "SHIFTREG_DIV_MODE"))
         text_func.append("  .FDA_FEEDBACK(4'b%s)," % get_pll_bits(pllinfo, "FDA_FEEDBACK", 4))
         text_func.append("  .FDA_RELATIVE(4'b%s)," % get_pll_bits(pllinfo, "FDA_RELATIVE", 4))
         text_func.append("  .DIVR(4'b%s)," % get_pll_bits(pllinfo, "DIVR", 4))


### PR DESCRIPTION
I was confronted with this when attempting to use icebox_vlog with a up5k image:

```
Traceback (most recent call last):
  File "/home/user/icestorm/icebox/./icebox_vlog.py", line 537, in <module>
    text_func.append("  .SHIFTREG_DIV_MODE(1'b%s)," % get_pll_bit(pllinfo, "SHIFTREG_DIV_MODE"))
  File "/home/user/icestorm/icebox/./icebox_vlog.py", line 186, in get_pll_bit
    bit = pllinfo[name]
KeyError: 'SHIFTREG_DIV_MODE'
```

The fault looks suspiciously like another fault already fixed by previous PR #263, and so I've applied the same @daveshah1 correction.