### PR TITLE
icebox_vlog: improve module declaration and unit testing

### DIFF
--- a/icebox/testcase/.gitignore
+++ b/icebox/testcase/.gitignore
@@ -1,0 +1,8 @@
+*.asc
+*.json
+*_tb
+*_syntb
+*_syn.v
+*.vcd
+*.rpt
+*.bin

--- a/icebox/testcase/Makefile
+++ b/icebox/testcase/Makefile
@@ -1,0 +1,73 @@
+PROJ = blinky
+
+PIN_DEF = blinky.pcf
+DEVICE = hx1k
+PACKAGE = tq144
+icebox_vlog_test_params := s l p c sl sp sc lp lc cp slp slc scp lcp slcp
+
+all: test
+
+test: icebox_vlog_test
+
+# Create test target list for icebox_vlog with different parameter options
+# composed of the case with no options, all of the options specified in
+# $(icebox_vlog_test_params), and all of the same cases with -C (Verilog-1995)
+# compatibilty.
+icebox_vlog_output := $(PROJ)_syn.v $(PROJ)-C_syn.v \
+	$(foreach case,$(icebox_vlog_test_params),$(PROJ)-$(case)_syn.v) \
+	$(foreach case,$(icebox_vlog_test_params),$(PROJ)-C$(case)_syn.v)
+icebox_vlog_iverilog_testlist := $(PROJ)_syntb $(PROJ)-C_syntb \
+	$(foreach case,$(icebox_vlog_test_params),$(PROJ)-$(case)_syntb) \
+	$(foreach case,$(icebox_vlog_test_params),$(PROJ)-C$(case)_syntb)
+icebox_vlog_yosys_testlist := $(PROJ)_syn.json $(PROJ)-C_syn.json \
+	$(foreach case,$(icebox_vlog_test_params),$(PROJ)-$(case)_syn.json) \
+	$(foreach case,$(icebox_vlog_test_params),$(PROJ)-C$(case)_syn.json)
+icebox_vlog_test: $(icebox_vlog_output) $(icebox_vlog_iverilog_testlist) $(icebox_vlog_yosys_testlist)
+
+%.json: %.v
+	yosys -p 'synth_ice40 -top $(PROJ) -json $@' $<
+
+%.asc: $(PIN_DEF) %.json
+	nextpnr-ice40 --$(DEVICE) --package $(PACKAGE) --asc $@ --pcf $< --json $*.json
+
+%.bin: %.asc
+	icepack $< $@
+
+%.rpt: %.asc
+	icetime -d $(DEVICE) -mtr $@ $<
+
+%_tb: %_tb.v %.v
+	iverilog -o $@ $^
+
+%_tb.vcd: %_tb
+	vvp -N $< +vcd=$@
+
+get_test_params = $(subst p,p $(PIN_DEF),\
+	$(filter-out $(1),\
+	$(1:$(PROJ)-%_syn.v=-%)))
+%_syn.v: $(PROJ).asc
+	../icebox_vlog.py -n blinky $(call get_test_params,$@) $^ > $@
+
+%_syntb: %_stb.v %_syn.v
+	iverilog -o $@ $^
+
+%_syntb.vcd: %_syntb
+	vvp -N $< +vcd=$@
+
+sim: $(PROJ)_tb.vcd
+
+postsim: $(PROJ)_syntb.vcd
+
+prog: $(PROJ).bin
+	iceprog $<
+
+sudo-prog: $(PROJ).bin
+	@echo 'Executing prog as root!!!'
+	sudo iceprog $<
+
+clean:
+	rm -f *.json $(PROJ).asc $(PROJ).rpt $(PROJ).bin \
+		*.vcd *_tb *_syntb *_syn.v
+
+.SECONDARY:
+.PHONY: all prog clean test icebox_vlog_test

--- a/icebox/testcase/blinky-C_stb.v
+++ b/icebox/testcase/blinky-C_stb.v
@@ -1,0 +1,1 @@
+blinky_stb.v

--- a/icebox/testcase/blinky-Cc_stb.v
+++ b/icebox/testcase/blinky-Cc_stb.v
@@ -1,0 +1,1 @@
+blinky_stb.v

--- a/icebox/testcase/blinky-Ccp_stb.v
+++ b/icebox/testcase/blinky-Ccp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-Cl_stb.v
+++ b/icebox/testcase/blinky-Cl_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-Clc_stb.v
+++ b/icebox/testcase/blinky-Clc_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-Clcp_stb.v
+++ b/icebox/testcase/blinky-Clcp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-Clp_stb.v
+++ b/icebox/testcase/blinky-Clp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky-Cp_stb.v
+++ b/icebox/testcase/blinky-Cp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky-Cs_stb.v
+++ b/icebox/testcase/blinky-Cs_stb.v
@@ -1,0 +1,1 @@
+blinky_stb.v

--- a/icebox/testcase/blinky-Csc_stb.v
+++ b/icebox/testcase/blinky-Csc_stb.v
@@ -1,0 +1,1 @@
+blinky_stb.v

--- a/icebox/testcase/blinky-Cscp_stb.v
+++ b/icebox/testcase/blinky-Cscp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-Csl_stb.v
+++ b/icebox/testcase/blinky-Csl_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-Cslc_stb.v
+++ b/icebox/testcase/blinky-Cslc_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-Cslcp_stb.v
+++ b/icebox/testcase/blinky-Cslcp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-Cslp_stb.v
+++ b/icebox/testcase/blinky-Cslp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky-Csp_stb.v
+++ b/icebox/testcase/blinky-Csp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky-c_stb.v
+++ b/icebox/testcase/blinky-c_stb.v
@@ -1,0 +1,35 @@
+// From nextpnr:ice40/examples/blinky
+// Original file due to Claire Xenia Wolf
+
+module blinky_tb;
+    reg clk;
+    always #5 clk = (clk === 1'b0);
+
+    wire led1, led2, led3, led4, led5;
+
+    blinky uut (
+        .io_0_8_1(clk),
+        .io_13_12_1(led1),
+        .io_13_12_0(led2),
+        .io_13_11_1(led3),
+        .io_13_11_0(led4),
+        .io_13_9_1(led5)
+    );
+
+    reg [4095:0] vcdfile;
+
+    initial begin
+        if ($value$plusargs("vcd=%s", vcdfile)) begin
+            $dumpfile(vcdfile);
+            $dumpvars(0, blinky_tb);
+        end
+    end
+
+    initial begin
+        repeat (10) begin
+            repeat (900000) @(posedge clk);
+            $display(led1, led2, led3, led4, led5);
+        end
+        $finish;
+    end
+endmodule

--- a/icebox/testcase/blinky-cp_stb.v
+++ b/icebox/testcase/blinky-cp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-l_stb.v
+++ b/icebox/testcase/blinky-l_stb.v
@@ -1,0 +1,35 @@
+// From nextpnr:ice40/examples/blinky
+// Original file due to Claire Xenia Wolf
+
+module blinky_tb;
+    reg clk;
+    always #5 clk = (clk === 1'b0);
+
+    wire led1, led2, led3, led4, led5;
+
+    blinky uut (
+        .pin_21(clk),
+        .pin_95(led1),
+        .pin_96(led2),
+        .pin_97(led3),
+        .pin_98(led4),
+        .pin_99(led5)
+    );
+
+    reg [4095:0] vcdfile;
+
+    initial begin
+        if ($value$plusargs("vcd=%s", vcdfile)) begin
+            $dumpfile(vcdfile);
+            $dumpvars(0, blinky_tb);
+        end
+    end
+
+    initial begin
+        repeat (10) begin
+            repeat (900000) @(posedge clk);
+            $display(led1, led2, led3, led4, led5);
+        end
+        $finish;
+    end
+endmodule

--- a/icebox/testcase/blinky-lc_stb.v
+++ b/icebox/testcase/blinky-lc_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-lcp_stb.v
+++ b/icebox/testcase/blinky-lcp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-lp_stb.v
+++ b/icebox/testcase/blinky-lp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky-p_stb.v
+++ b/icebox/testcase/blinky-p_stb.v
@@ -1,0 +1,35 @@
+// From nextpnr:ice40/examples/blinky
+// Original file due to Claire Xenia Wolf
+
+module blinky_tb;
+    reg clk;
+    always #5 clk = (clk === 1'b0);
+
+    wire led1, led2, led3, led4, led5;
+
+    blinky uut (
+        .clki (clk),
+        .\led[0] (led1),
+        .\led[1] (led2),
+        .\led[2] (led3),
+        .\led[3] (led4),
+        .\led[4] (led5)
+    );
+
+    reg [4095:0] vcdfile;
+
+    initial begin
+        if ($value$plusargs("vcd=%s", vcdfile)) begin
+            $dumpfile(vcdfile);
+            $dumpvars(0, blinky_tb);
+        end
+    end
+
+    initial begin
+        repeat (10) begin
+            repeat (900000) @(posedge clk);
+            $display(led1, led2, led3, led4, led5);
+        end
+        $finish;
+    end
+endmodule

--- a/icebox/testcase/blinky-s_stb.v
+++ b/icebox/testcase/blinky-s_stb.v
@@ -1,0 +1,1 @@
+blinky_stb.v

--- a/icebox/testcase/blinky-sc_stb.v
+++ b/icebox/testcase/blinky-sc_stb.v
@@ -1,0 +1,1 @@
+blinky_stb.v

--- a/icebox/testcase/blinky-scp_stb.v
+++ b/icebox/testcase/blinky-scp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-sl_stb.v
+++ b/icebox/testcase/blinky-sl_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-slc_stb.v
+++ b/icebox/testcase/blinky-slc_stb.v
@@ -1,0 +1,1 @@
+blinky-l_stb.v

--- a/icebox/testcase/blinky-slcp_stb.v
+++ b/icebox/testcase/blinky-slcp_stb.v
@@ -1,0 +1,1 @@
+blinky_tb.v

--- a/icebox/testcase/blinky-slp_stb.v
+++ b/icebox/testcase/blinky-slp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky-sp_stb.v
+++ b/icebox/testcase/blinky-sp_stb.v
@@ -1,0 +1,1 @@
+blinky-p_stb.v

--- a/icebox/testcase/blinky.pcf
+++ b/icebox/testcase/blinky.pcf
@@ -1,0 +1,9 @@
+# From nextpnr:ice40/examples/blinky
+# Original file due to David Shah
+
+set_io led[0] 99
+set_io led[1] 98
+set_io led[2] 97
+set_io led[3] 96
+set_io led[4] 95
+set_io clki 21

--- a/icebox/testcase/blinky.v
+++ b/icebox/testcase/blinky.v
@@ -1,0 +1,23 @@
+// From nextpnr:ice40/examples/blinky
+// Original file due to Claire Xenia Wolf
+
+module blinky (
+    input  clki,
+    output [4:0] led
+);
+
+    assign clk = clki;
+
+    localparam BITS = 5;
+    localparam LOG2DELAY = 21;
+
+    reg [BITS+LOG2DELAY-1:0] counter = 0;
+    reg [BITS-1:0] outcnt;
+
+    always @(posedge clk) begin
+        counter <= counter + 1;
+        outcnt <= counter >> LOG2DELAY;
+    end
+
+    assign led = outcnt ^ (outcnt >> 1);
+endmodule

--- a/icebox/testcase/blinky_stb.v
+++ b/icebox/testcase/blinky_stb.v
@@ -1,0 +1,1 @@
+blinky-c_stb.v

--- a/icebox/testcase/blinky_tb.v
+++ b/icebox/testcase/blinky_tb.v
@@ -1,0 +1,31 @@
+// From nextpnr:ice40/examples/blinky
+// Original file due to Claire Xenia Wolf
+
+module blinky_tb;
+    reg clk;
+    always #5 clk = (clk === 1'b0);
+
+    wire led1, led2, led3, led4, led5;
+
+    blinky uut (
+        .clki (clk),
+        .\led ({led1, led2, led3, led4, led5})
+    );
+
+    reg [4095:0] vcdfile;
+
+    initial begin
+        if ($value$plusargs("vcd=%s", vcdfile)) begin
+            $dumpfile(vcdfile);
+            $dumpvars(0, blinky_tb);
+        end
+    end
+
+    initial begin
+        repeat (10) begin
+            repeat (900000) @(posedge clk);
+            $display(led1, led2, led3, led4, led5);
+        end
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
Resolves #328

- icebox_vlog: use proper Verilog-2001 module declarations
- icebox_vlog: add basic test cases

First commit changes iceblox_vlog to output Verilog-2001 module declarations
by default. An additional command line option (-C) supports output of
Verilog-1995 module declarations for backwards compatibility.

Second commit adds test cases that try out different combinations of
commandline options for iceblox_vlog and ensure they parse correctly with
iverilog and yosys.
I didn't see any other obvious regression tests, so I added these to support
development in the future.

