### PR TITLE
Settings to build pdf documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,3 +33,5 @@ html_theme_options = {
     "titles_only": False
 }
 html_static_path = ['_static']
+
+latex_engine = 'lualatex'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,9 @@ author = 'YosysHQ'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['sphinx_rtd_theme']
+extensions = ['sphinx_rtd_theme',
+              'sphinxcontrib.rsvgconverter'
+              ]
 
 templates_path = ['_templates']
 exclude_patterns = []

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme 
+sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
- add sphinx extension to convert svg to pdf
- use Lualatex instead of plain pdflatex which works will all utf-8 characters