### PR TITLE
Iceprog: Fixed the intermittent progress counter under windows 10 and python pipe

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -1009,6 +1009,7 @@ int main(int argc, char **argv)
 						break;
 					fprintf(stderr, "                      \r");
 					fprintf(stderr, "addr 0x%06X %3ld%%\r", rw_offset + addr, 100 * addr / file_size);
+					fflush(stderr);
 					flash_write_enable();
 					flash_prog(rw_offset + addr, buffer, rc);
 					flash_wait();
@@ -1031,6 +1032,7 @@ int main(int argc, char **argv)
 				uint8_t buffer[256];
 				fprintf(stderr, "                      \r");
 				fprintf(stderr, "addr 0x%06X %3d%%\r", rw_offset + addr, 100 * addr / read_size);
+				fflush(stderr);
 				flash_read(rw_offset + addr, buffer, 256);
 				fwrite(buffer, read_size - addr > 256 ? 256 : read_size - addr, 1, f);
 			}
@@ -1045,6 +1047,7 @@ int main(int argc, char **argv)
 					break;
 				fprintf(stderr, "                      \r");
 				fprintf(stderr, "addr 0x%06X %3ld%%\r", rw_offset + addr, 100 * addr / file_size);
+				fflush(stderr);
 				flash_read(rw_offset + addr, buffer_flash, rc);
 				if (memcmp(buffer_file, buffer_flash, rc)) {
 					fprintf(stderr, "Found difference between flash and file!\n");


### PR DESCRIPTION
This minimal PR fixes the `iceprog` intermittent progress counter issue that was observed under some conditions, per https://github.com/YosysHQ/icestorm/issues/350. 

It forces `fflush()` each time a progress-counter `\r` line is written to stderr to make sure it's not buffered. 



 